### PR TITLE
[FE Feat] PostList 페이지 레이아웃 구현

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,14 +1,21 @@
 import { Reset } from 'styled-reset';
 import './App.css';
-import Singin from './components/templates/Signin';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import Signin from './components/templates/Signin';
 import Navigator from './components/organisms/Navigator';
+import PostList from './components/templates/PostList';
 
 const App = () => {
   return (
     <>
       <Reset />
       <Navigator />
-      <Singin />
+      <BrowserRouter>
+        <Routes>
+          <Route path="/signin" element={<Signin />} />
+          <Route path="/posts" element={<PostList />} />
+        </Routes>
+      </BrowserRouter>
     </>
   );
 };

--- a/client/src/components/molecules/Post.js
+++ b/client/src/components/molecules/Post.js
@@ -1,0 +1,19 @@
+import styled from 'styled-components';
+
+const Container = styled.div`
+  display: flex;
+  width: inherit;
+  height: 80px;
+  background-color: lightcoral;
+  border: 1px solid black;
+`;
+
+const Post = () => {
+  return (
+    <Container>
+      <div>Post</div>
+    </Container>
+  );
+};
+
+export default Post;

--- a/client/src/components/organisms/postlist/PostListContainer.js
+++ b/client/src/components/organisms/postlist/PostListContainer.js
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+import Post from '../../molecules/Post';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: inherit;
+  background-color: lightcoral;
+`;
+
+const PostListContainer = () => {
+  return (
+    <Container>
+      <Post />
+      <Post />
+      <Post />
+      <Post />
+    </Container>
+  );
+};
+
+export default PostListContainer;

--- a/client/src/components/organisms/postlist/PostListFilter.js
+++ b/client/src/components/organisms/postlist/PostListFilter.js
@@ -1,0 +1,27 @@
+import styled from 'styled-components';
+
+const Container = styled.div`
+  display: flex;
+  width: inherit;
+  height: 50px;
+  justify-content: space-around;
+  align-items: center;
+  background-color: moccasin;
+`;
+
+const FilterContainer = () => {
+  return (
+    <Container>
+      <div>
+        <span>Post </span>
+        <span> Series</span>
+      </div>
+      <div>
+        <button type="button">최신순</button>
+        <button type="button">추천순</button>
+      </div>
+    </Container>
+  );
+};
+
+export default FilterContainer;

--- a/client/src/components/organisms/postlist/PostListHeader.js
+++ b/client/src/components/organisms/postlist/PostListHeader.js
@@ -1,0 +1,21 @@
+import styled from 'styled-components';
+
+const Container = styled.div`
+  display: flex;
+  width: inherit;
+  height: 100px;
+  background-color: aqua;
+  align-items: center;
+  justify-content: space-around;
+`;
+
+const PostListHeaderContainer = () => {
+  return (
+    <Container>
+      <h1>Post In Category</h1>
+      <button type="button">Create Post</button>
+    </Container>
+  );
+};
+
+export default PostListHeaderContainer;

--- a/client/src/components/organisms/postlist/PostListPagination.js
+++ b/client/src/components/organisms/postlist/PostListPagination.js
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+
+const Container = styled.div`
+  display: flex;
+  width: inherit;
+  height: 50px;
+  align-items: center;
+  justify-content: center;
+  background-color: lightblue;
+`;
+
+const PaginationContainer = () => {
+  return (
+    <Container>
+      <button type="button">1</button>
+      <button type="button">2</button>
+      <button type="button">3</button>
+      <button type="button">4</button>
+      <button type="button">5</button>
+    </Container>
+  );
+};
+
+export default PaginationContainer;

--- a/client/src/components/templates/PostList.js
+++ b/client/src/components/templates/PostList.js
@@ -1,0 +1,69 @@
+import styled from 'styled-components';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 1024px;
+  margin: 0 auto;
+  padding-top: 100px;
+  justify-content: center;
+  align-items: center;
+`;
+
+const ListHeaderContainer = styled.div`
+  display: flex;
+  width: inherit;
+  height: 100px;
+  background-color: aqua;
+  align-items: center;
+  justify-content: center;
+`;
+
+const FilterContainer = styled.div`
+  display: flex;
+  width: inherit;
+  height: 50px;
+  background-color: moccasin;
+`;
+
+const PostListContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: inherit;
+`;
+
+const PaginationContainer = styled.div`
+  display: flex;
+  width: inherit;
+  height: 50px;
+  align-items: center;
+  justify-content: center;
+  background-color: lightblue;
+`;
+
+const PostList = () => {
+  return (
+    <Container>
+      <ListHeaderContainer>
+        <h1>POST IN CATEGORY</h1>
+        <button type="button">Create Post</button>
+      </ListHeaderContainer>
+      <FilterContainer>
+        <div>Post</div>
+        <div>Series</div>
+      </FilterContainer>
+      <PostListContainer>
+        <div />
+      </PostListContainer>
+      <PaginationContainer>
+        <button type="button">1</button>
+        <button type="button">2</button>
+        <button type="button">3</button>
+        <button type="button">4</button>
+        <button type="button">5</button>
+      </PaginationContainer>
+    </Container>
+  );
+};
+
+export default PostList;

--- a/client/src/components/templates/PostList.js
+++ b/client/src/components/templates/PostList.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import PostListHeaderContainer from '../organisms/postlist/PostListHeader';
+import FilterContainer from '../organisms/postlist/PostListFilter';
 
 const Container = styled.div`
   display: flex;
@@ -9,13 +10,6 @@ const Container = styled.div`
   padding-top: 100px;
   justify-content: center;
   align-items: center;
-`;
-
-const FilterContainer = styled.div`
-  display: flex;
-  width: inherit;
-  height: 50px;
-  background-color: moccasin;
 `;
 
 const PostListContainer = styled.div`
@@ -37,10 +31,7 @@ const PostList = () => {
   return (
     <Container>
       <PostListHeaderContainer />
-      <FilterContainer>
-        <div>Post</div>
-        <div>Series</div>
-      </FilterContainer>
+      <FilterContainer />
       <PostListContainer>
         <div />
       </PostListContainer>

--- a/client/src/components/templates/PostList.js
+++ b/client/src/components/templates/PostList.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import PostListHeaderContainer from '../organisms/postlist/PostListHeader';
 
 const Container = styled.div`
   display: flex;
@@ -8,15 +9,6 @@ const Container = styled.div`
   padding-top: 100px;
   justify-content: center;
   align-items: center;
-`;
-
-const ListHeaderContainer = styled.div`
-  display: flex;
-  width: inherit;
-  height: 100px;
-  background-color: aqua;
-  align-items: center;
-  justify-content: center;
 `;
 
 const FilterContainer = styled.div`
@@ -44,10 +36,7 @@ const PaginationContainer = styled.div`
 const PostList = () => {
   return (
     <Container>
-      <ListHeaderContainer>
-        <h1>POST IN CATEGORY</h1>
-        <button type="button">Create Post</button>
-      </ListHeaderContainer>
+      <PostListHeaderContainer />
       <FilterContainer>
         <div>Post</div>
         <div>Series</div>

--- a/client/src/components/templates/PostList.js
+++ b/client/src/components/templates/PostList.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import PostListHeaderContainer from '../organisms/postlist/PostListHeader';
 import FilterContainer from '../organisms/postlist/PostListFilter';
+import PaginationContainer from '../organisms/postlist/PostListPagination';
 
 const Container = styled.div`
   display: flex;
@@ -18,15 +19,6 @@ const PostListContainer = styled.div`
   width: inherit;
 `;
 
-const PaginationContainer = styled.div`
-  display: flex;
-  width: inherit;
-  height: 50px;
-  align-items: center;
-  justify-content: center;
-  background-color: lightblue;
-`;
-
 const PostList = () => {
   return (
     <Container>
@@ -35,13 +27,7 @@ const PostList = () => {
       <PostListContainer>
         <div />
       </PostListContainer>
-      <PaginationContainer>
-        <button type="button">1</button>
-        <button type="button">2</button>
-        <button type="button">3</button>
-        <button type="button">4</button>
-        <button type="button">5</button>
-      </PaginationContainer>
+      <PaginationContainer />
     </Container>
   );
 };

--- a/client/src/components/templates/PostList.js
+++ b/client/src/components/templates/PostList.js
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import PostListHeaderContainer from '../organisms/postlist/PostListHeader';
 import FilterContainer from '../organisms/postlist/PostListFilter';
 import PaginationContainer from '../organisms/postlist/PostListPagination';
+import PostListContainer from '../organisms/postlist/PostListContainer';
 
 const Container = styled.div`
   display: flex;
@@ -13,20 +14,12 @@ const Container = styled.div`
   align-items: center;
 `;
 
-const PostListContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  width: inherit;
-`;
-
 const PostList = () => {
   return (
     <Container>
       <PostListHeaderContainer />
       <FilterContainer />
-      <PostListContainer>
-        <div />
-      </PostListContainer>
+      <PostListContainer />
       <PaginationContainer />
     </Container>
   );

--- a/client/src/components/templates/Signin.js
+++ b/client/src/components/templates/Signin.js
@@ -18,7 +18,7 @@ const Body = styled.div`
   background-color: white;
 `;
 
-const Singin = () => {
+const Signin = () => {
   return (
     <Container>
       <Body>
@@ -29,4 +29,4 @@ const Singin = () => {
   );
 };
 
-export default Singin;
+export default Signin;


### PR DESCRIPTION
## PostList 페이지 레이아웃 구현
- PostList 페이지 전체 레이아웃 구성
- Header, Filter, List, Pagination 컴포넌트 분리 (organisms)
- 개별 Post 컴포넌트 분리 (molecules)

## 미리보기
<img width="1243" alt="스크린샷 2023-01-09 오후 4 05 52" src="https://user-images.githubusercontent.com/110910408/211255920-e027cd59-8433-4be7-9fae-fa9259d14f5a.png">

closes #22 
