### PR TITLE
[BE/Showcase] Service 1차 및 Controller 2차 구현

### DIFF
--- a/server/src/main/java/com/codestates/hobby/domain/showcase/controller/ShowcaseCommendController.java
+++ b/server/src/main/java/com/codestates/hobby/domain/showcase/controller/ShowcaseCommendController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.codestates.hobby.domain.showcase.dto.ShowcaseDto;
+import com.codestates.hobby.domain.showcase.service.ShowcaseService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,11 +26,17 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @RequestMapping("/showcases")
 public class ShowcaseCommendController {
+	private final ShowcaseService showcaseService;
+
 	@PostMapping(consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
 	public ResponseEntity<?> post(
 		@RequestPart(value = "imgFiles") List<MultipartFile> imgFiles,
-		@RequestPart(value = "request") ShowcaseDto.Post post
+		@RequestPart(value = "request") ShowcaseDto.Post post,
+		@AuthenticationPrincipal Long memberId
 	) {
+		post.setProperties(memberId, imgFiles);
+
+		showcaseService.post(post);
 
 		return new ResponseEntity<>(HttpStatus.CREATED);
 	}
@@ -37,16 +45,24 @@ public class ShowcaseCommendController {
 		value = "/{showcase-id}",
 		consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
 	public ResponseEntity<?> patch(
-		@PathVariable("showcase-id") long showcaseId,
 		@RequestPart(value = "imgFiles") List<MultipartFile> imgFiles,
-		@RequestPart(value = "request") ShowcaseDto.Patch patch
+		@RequestPart(value = "request") ShowcaseDto.Patch patch,
+		@PathVariable("showcase-id") long showcaseId,
+		@AuthenticationPrincipal Long memberId
 	) {
+		patch.setProperties(memberId, showcaseId, imgFiles);
+
+		showcaseService.update(patch);
 
 		return new ResponseEntity<>(HttpStatus.OK);
 	}
 
 	@DeleteMapping("/{showcase-id}")
-	public ResponseEntity<?> delete(@PathVariable("showcase-id") long showcaseId) {
+	public ResponseEntity<?> delete(
+		@PathVariable("showcase-id") long showcaseId,
+		@AuthenticationPrincipal Long memberId
+	) {
+		showcaseService.delete(memberId, showcaseId);
 
 		return new ResponseEntity<>(HttpStatus.NO_CONTENT);
 	}

--- a/server/src/main/java/com/codestates/hobby/domain/showcase/controller/ShowcaseCommentController.java
+++ b/server/src/main/java/com/codestates/hobby/domain/showcase/controller/ShowcaseCommentController.java
@@ -2,8 +2,10 @@ package com.codestates.hobby.domain.showcase.controller;
 
 import javax.validation.constraints.NotBlank;
 
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -11,7 +13,11 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.codestates.hobby.domain.showcase.entity.ShowcaseComment;
+import com.codestates.hobby.domain.showcase.service.ShowcaseCommentService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -19,16 +25,28 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/showcases/{showcase-id}/comments")
 public class ShowcaseCommentController {
+	private final ShowcaseCommentService commentService;
+
 	@GetMapping
-	public ResponseEntity<?> getAll(@PathVariable("showcase-id") long showcaseId) {
+	public ResponseEntity<?> getAll(
+		@PathVariable("showcase-id") long showcaseId,
+		@RequestParam(defaultValue = "1") int page,
+		@RequestParam(defaultValue = "10") int size,
+		@AuthenticationPrincipal Long memberId
+	) {
+		Page<ShowcaseComment> comments = commentService.findAll(showcaseId, page, size);
+
 		return new ResponseEntity<>(HttpStatus.OK);
 	}
 
 	@PostMapping
 	public ResponseEntity<?> post(
 		@PathVariable("showcase-id") long showcaseId,
+		@AuthenticationPrincipal Long memberId,
 		@RequestBody @NotBlank String content
 	) {
+		commentService.post(memberId, showcaseId, content);
+
 		return new ResponseEntity<>(HttpStatus.CREATED);
 	}
 
@@ -36,16 +54,22 @@ public class ShowcaseCommentController {
 	public ResponseEntity<?> patch(
 		@PathVariable("showcase-id") long showcaseId,
 		@PathVariable("comment-id") long commentId,
+		@AuthenticationPrincipal Long memberId,
 		@RequestBody @NotBlank String content
 	) {
+		commentService.update(memberId, showcaseId, commentId, content);
+
 		return new ResponseEntity<>(HttpStatus.OK);
 	}
 
 	@DeleteMapping("/{comment-id}")
 	public ResponseEntity<?> delete(
 		@PathVariable("showcase-id") long showcaseId,
-		@PathVariable("comment-id") long commentId
+		@PathVariable("comment-id") long commentId,
+		@AuthenticationPrincipal Long memberId
 	) {
+		commentService.delete(memberId, showcaseId, commentId);
+
 		return new ResponseEntity<>(HttpStatus.NO_CONTENT);
 	}
 }

--- a/server/src/main/java/com/codestates/hobby/domain/showcase/controller/ShowcaseQueryController.java
+++ b/server/src/main/java/com/codestates/hobby/domain/showcase/controller/ShowcaseQueryController.java
@@ -1,11 +1,17 @@
 package com.codestates.hobby.domain.showcase.controller;
 
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.codestates.hobby.domain.showcase.entity.Showcase;
+import com.codestates.hobby.domain.showcase.service.ShowcaseService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -13,23 +19,50 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping
 @RequiredArgsConstructor
 public class ShowcaseQueryController {
+	private final ShowcaseService showcaseService;
+
 	@GetMapping("/showcases/{showcase-id}")
-	public ResponseEntity<?> get(@PathVariable("showcase-id") long showcaseId) {
-		return new ResponseEntity<>(HttpStatus.OK);
+	public ResponseEntity<?> get(@AuthenticationPrincipal Long memberId, @PathVariable("showcase-id") long showcaseId) {
+		Showcase showcase = showcaseService.findById(showcaseId);
+
+		return new ResponseEntity<>(showcase, HttpStatus.OK);
 	}
 
 	@GetMapping("/showcases")
-	public ResponseEntity<?> getAll() {
+	public ResponseEntity<?> getAll(
+		@AuthenticationPrincipal Long memberId,
+		@RequestParam(defaultValue = "1") int page,
+		@RequestParam(defaultValue = "1") int size,
+		@RequestParam(defaultValue = "NEWEST") String sort
+	) {
+		Page<Showcase> showcases = showcaseService.findAll(page, size, sort.equalsIgnoreCase("NEWEST"));
+
 		return new ResponseEntity<>(HttpStatus.OK);
 	}
 
 	@GetMapping("/categories/{category-name}/showcases")
-	public ResponseEntity<?> getAllByCategory(@PathVariable("category-name") String category) {
+	public ResponseEntity<?> getAllByCategory(
+		@AuthenticationPrincipal Long memberId,
+		@RequestParam(defaultValue = "1") int page,
+		@RequestParam(defaultValue = "1") int size,
+		@RequestParam(defaultValue = "NEWEST") String sort,
+		@PathVariable("category-name") String category
+	) {
+		Page<Showcase> showcases = showcaseService.findAllByCategory(category, page, size, sort.equalsIgnoreCase("NEWEST"));
+
 		return new ResponseEntity<>(HttpStatus.OK);
 	}
 
 	@GetMapping("/members/{member-id}/showcases")
-	public ResponseEntity<?> getAllByMember(@PathVariable("member-id") long memberId) {
+	public ResponseEntity<?> getAllByMember(
+		@AuthenticationPrincipal Long authMemberId,
+		@PathVariable("member-id") long memberId,
+		@RequestParam(defaultValue = "1") int page,
+		@RequestParam(defaultValue = "1") int size,
+		@RequestParam(defaultValue = "NEWEST") String sort
+	) {
+		Page<Showcase> showcases = showcaseService.findAllByMember(memberId, page, size, sort.equalsIgnoreCase("NEWEST"));
+
 		return new ResponseEntity<>(HttpStatus.OK);
 	}
 }

--- a/server/src/main/java/com/codestates/hobby/domain/showcase/dto/ShowcaseDto.java
+++ b/server/src/main/java/com/codestates/hobby/domain/showcase/dto/ShowcaseDto.java
@@ -3,6 +3,10 @@ package com.codestates.hobby.domain.showcase.dto;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.springframework.web.multipart.MultipartFile;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -11,17 +15,35 @@ public class ShowcaseDto {
 	@Getter
 	@Setter
 	@NoArgsConstructor
+	@JsonIgnoreProperties({"memberId", "imgFiles"})
 	public static class Post {
+		private Long memberId;
 		private String content;
 		private String category;
+		private List<MultipartFile> imgFiles;
+
+		public void setProperties(Long memberId, List<MultipartFile> imgFiles) {
+			this.memberId = memberId;
+			this.imgFiles = imgFiles;
+		}
 	}
 
 	@Getter
 	@Setter
 	@NoArgsConstructor
+	@JsonIgnoreProperties({"memberId", "showcaseId", "imgFiles"})
 	public static class Patch {
+		private Long memberId;
+		private Long showcaseId;
 		private String content;
 		private String category;
+		private List<MultipartFile> imgFiles;
+
+		public void setProperties(Long memberId, Long showcaseId, List<MultipartFile> imgFiles) {
+			this.showcaseId = showcaseId;
+			this.memberId = memberId;
+			this.imgFiles = imgFiles;
+		}
 	}
 
 	@Getter

--- a/server/src/main/java/com/codestates/hobby/domain/showcase/service/ShowcaseCommentService.java
+++ b/server/src/main/java/com/codestates/hobby/domain/showcase/service/ShowcaseCommentService.java
@@ -29,7 +29,7 @@ public class ShowcaseCommentService {
 	}
 
 	@Transactional(readOnly = true)
-	public Page<ShowcaseComment> findAll(int page, int size) {
+	public Page<ShowcaseComment> findAll(long showcaseId, int page, int size) {
 		return null;
 	}
 }

--- a/server/src/main/java/com/codestates/hobby/domain/showcase/service/ShowcaseCommentService.java
+++ b/server/src/main/java/com/codestates/hobby/domain/showcase/service/ShowcaseCommentService.java
@@ -1,0 +1,35 @@
+package com.codestates.hobby.domain.showcase.service;
+
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.codestates.hobby.domain.showcase.entity.ShowcaseComment;
+
+@Service
+public class ShowcaseCommentService {
+	@Transactional
+	public void post(long memberId, long showcaseId, String content) {
+
+	}
+
+	@Transactional
+	public void update(long memberId, long showcaseId, long commentId, String content) {
+
+	}
+
+	@Transactional
+	public void delete(long memberId, long showcaseId, long commentId) {
+
+	}
+
+	@Transactional(readOnly = true)
+	public int getCount(long showcaseId) {
+		return 0;
+	}
+
+	@Transactional(readOnly = true)
+	public Page<ShowcaseComment> findAll(int page, int size) {
+		return null;
+	}
+}

--- a/server/src/main/java/com/codestates/hobby/domain/showcase/service/ShowcaseService.java
+++ b/server/src/main/java/com/codestates/hobby/domain/showcase/service/ShowcaseService.java
@@ -1,0 +1,64 @@
+package com.codestates.hobby.domain.showcase.service;
+
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.codestates.hobby.domain.showcase.dto.ShowcaseDto;
+import com.codestates.hobby.domain.showcase.entity.Showcase;
+
+@Service
+public class ShowcaseService {
+	@Transactional
+	public void post(ShowcaseDto.Post postDto) {
+		// 0. 검증
+		// 1. 이미지를 저장한다.
+		// 2. 성공하면 Showcase를 저장한다.
+		//    - 실패시 저장된 이미지를 지워야됨
+		// * (Optional) 구독자들에게 알림
+	}
+
+	@Transactional
+	public void update(ShowcaseDto.Patch patch) {
+		// 0. 검증
+		// 1. 이미지를 저장한다. (변경됐다면)
+		// 2. 성공하면 Showcase를 수정한다.
+		//    - 실패시 저장된 이미지를 지워야됨 (변경된것만)
+	}
+
+	@Transactional
+	public void delete(long memberId, long showcaseId) {
+
+	}
+
+	@Transactional
+	public Showcase findById(long showcaseId) {
+		// 조회수를 증가시킨다.
+		return null;
+	}
+
+	@Transactional(readOnly = true)
+	public Showcase findWithoutIncreasingViewsById(long showcaseId) {
+		return null;
+	}
+
+	@Transactional(readOnly = true)
+	public Page<Showcase> findByQuery(String query, int page, int size) {
+		return null;
+	}
+
+	@Transactional(readOnly = true)
+	public Page<Showcase> findAll(int page, int size, boolean isNewest) {
+		return null;
+	}
+
+	@Transactional(readOnly = true)
+	public Page<Showcase> findAllByMember(long memberId, int page, int size, boolean isNewest) {
+		return null;
+	}
+
+	@Transactional(readOnly = true)
+	public Page<Showcase> findAllByCategory(String categoryName, int page, int size, boolean isNewest) {
+		return null;
+	}
+}


### PR DESCRIPTION
## 개요
- [#33] Showcase 및 Showcase Comment Service 1차 구현
- [#34] Showcase 및 Showcase Comment Controller 2차 구현

## 작업내용
- Service에 메서드 선언만 해놓음
- 각각의 Controller 메서드마다 적절한 Service 메서드를 호출함
- DTO에 필드를 추가해서 컨트롤러에서 서비스로 넘기는 값들을 DTO에 할당함

## 변경사항 
- 페이징 파라미터를 받아야하는 `getAll` 메서드에 파라미터를 추가했습니다.
  - 추후 페이징 파라미터들을 감싸는 클래스로 바꿀예정
- 핸들러 메서드에 필요한 파라미터들을 선언했습니다.

## 기타
- `@AuthenticationPrincipal`
  - 인증과정에서 **인증된** 회원의 정보는 `SecurityContextHolder`에 저장됩니다, 
  - 이때 `Authentication` 객체의 `Principal` 필드에 저장되는 정보가 해당 어노테이션이 선언된 객체에 바인딩됩니다. (바인딩하는 클래스: `AuthenticationPrincipalArgumentResolver`)
  - 주의할 점
    1. 인증 유저가 없다면 **"String" 타입**의 "anonymousUser"가 값으로 할당됩니다.
    2. `Principal` 필드에 어떤 타입의 객체를 할당했느냐에 따라서 클래스를 변경해야됩니다.
        > ex. `Principal`에 `Member` 타입의 객체를 할당했다면 `@AuthenticationPrincipal Member authMember` 또는 `@AuthenticationPrincipal Object object` 형식으로 사용해야됨
