### PR TITLE
[BE] 공통 설정

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -19,20 +19,28 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    // 스프링 부터
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-    compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'com.h2database:h2'
-    annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    implementation 'org.mapstruct:mapstruct:1.5.1.Final'
-    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.1.Final'
-    implementation 'org.springframework.boot:spring-boot-starter-mail'
-    implementation 'org.apache.tomcat.embed:tomcat-embed-jasper'
-    implementation 'com.google.code.gson:gson'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+    // 유틸성 라이브러리
+    implementation 'org.apache.tomcat.embed:tomcat-embed-jasper'
+    implementation 'org.mapstruct:mapstruct:1.5.3.Final'
+    implementation 'org.apache.commons:commons-lang3'
+    implementation 'com.google.code.gson:gson'
+
+    runtimeOnly 'com.h2database:h2'
+    compileOnly 'org.projectlombok:lombok'
+
+    annotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final'
+    annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 }
 
 tasks.named('test') {

--- a/server/src/main/java/com/codestates/hobby/global/config/MvcConfig.java
+++ b/server/src/main/java/com/codestates/hobby/global/config/MvcConfig.java
@@ -1,10 +1,14 @@
 package com.codestates.hobby.global.config;
 
+import java.util.List;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import com.codestates.hobby.global.config.support.PagingArgumentResolver;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
@@ -20,5 +24,11 @@ public class MvcConfig implements WebMvcConfigurer {
 			.visibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
 			.visibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE)
 			.visibility(PropertyAccessor.SETTER, JsonAutoDetect.Visibility.NONE);
+	}
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		WebMvcConfigurer.super.addArgumentResolvers(resolvers);
+		resolvers.add(new PagingArgumentResolver());
 	}
 }

--- a/server/src/main/java/com/codestates/hobby/global/config/MvcConfig.java
+++ b/server/src/main/java/com/codestates/hobby/global/config/MvcConfig.java
@@ -1,0 +1,24 @@
+package com.codestates.hobby.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+@Configuration
+public class MvcConfig implements WebMvcConfigurer {
+	@Bean
+	public Jackson2ObjectMapperBuilder objectMapperBuilder() {
+		return new Jackson2ObjectMapperBuilder()
+			.serializationInclusion(JsonInclude.Include.NON_NULL)
+			.featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+			.visibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
+			.visibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE)
+			.visibility(PropertyAccessor.SETTER, JsonAutoDetect.Visibility.NONE);
+	}
+}

--- a/server/src/main/java/com/codestates/hobby/global/config/support/CustomPageRequest.java
+++ b/server/src/main/java/com/codestates/hobby/global/config/support/CustomPageRequest.java
@@ -1,0 +1,25 @@
+package com.codestates.hobby.global.config.support;
+
+import org.springframework.data.domain.PageRequest;
+
+import lombok.Getter;
+
+@Getter
+public class CustomPageRequest {
+	private final int page;
+	private final int size;
+
+	public CustomPageRequest(int page, int size) {
+		if (page < 1)
+			throw new IllegalArgumentException("Page must be greater than zero.");
+		if (size < 1)
+			throw new IllegalArgumentException("Size must be greater than zero.");
+
+		this.page = page - 1;
+		this.size = size;
+	}
+
+	public PageRequest to() {
+		return PageRequest.of(page, size);
+	}
+}

--- a/server/src/main/java/com/codestates/hobby/global/config/support/PagingArgumentResolver.java
+++ b/server/src/main/java/com/codestates/hobby/global/config/support/PagingArgumentResolver.java
@@ -1,0 +1,40 @@
+package com.codestates.hobby.global.config.support;
+
+import static org.springframework.util.StringUtils.*;
+
+import org.apache.commons.lang3.math.NumberUtils;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class PagingArgumentResolver implements HandlerMethodArgumentResolver {
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return parameter.getClass().isAssignableFrom(CustomPageRequest.class);
+	}
+
+	@Override
+	public Object resolveArgument(
+		MethodParameter methodParameter,
+		ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest,
+		WebDataBinderFactory binderFactory
+	) {
+		String pageStr = webRequest.getParameter("page");
+		String sizeStr = webRequest.getParameter("size");
+
+		if (!hasText(pageStr) && !hasText(sizeStr))
+			return null;
+
+		// TODO: 컨트롤러마다 기본값이 다름.
+		//     : 각자 디폴트 Value를 설정할 수 있어야됨.
+		// 1. Flag와 page, size 인터페이스를 만들어서 메서드 핸들러가 실행된 이후 재설정을 강제한다.
+		// 2. 제네릭...? -> 제네릭의 실제 타입을 현재 스코프에서 불러올 수 있는 방법을 모르겠음.
+		int page = NumberUtils.toInt(pageStr, 1);
+		int size = NumberUtils.toInt(sizeStr, 5);
+
+		return new CustomPageRequest(page, size);
+	}
+}

--- a/server/src/main/java/com/codestates/hobby/global/dto/MultiResponseDto.java
+++ b/server/src/main/java/com/codestates/hobby/global/dto/MultiResponseDto.java
@@ -1,0 +1,23 @@
+package com.codestates.hobby.global.dto;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+import lombok.Getter;
+
+@Getter
+public class MultiResponseDto<T> {
+	private final List<T> data;
+	private final PageInfo pageInfo;
+
+	public MultiResponseDto(Page<T> page) {
+		this.data = page.getContent();
+		this.pageInfo = new PageInfo(
+			page.getNumber() + 1,
+			page.getSize(),
+			page.getTotalPages(),
+			page.getTotalElements()
+		);
+	}
+}

--- a/server/src/main/java/com/codestates/hobby/global/dto/PageInfo.java
+++ b/server/src/main/java/com/codestates/hobby/global/dto/PageInfo.java
@@ -1,0 +1,13 @@
+package com.codestates.hobby.global.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PageInfo {
+	private int page;
+	private int size;
+	private int totalPages;
+	private long totalElements;
+}


### PR DESCRIPTION
## 개요
- [#42]
- Jackson Object Mapper 설정 
- Build.gradle 라이브러리 정렬 및 추가
- Paging Argument Resolver 구현
- Multi Response Dto 구현

## 작업내용
- Jackson Object Mapper 설정내용
  - 직렬화할 때 값이 NULL인 키는 제외함
  - FIELD를 통해서만 역직렬화 또는 직렬화함
  
- Build.gradle
  - 추가된 라이브러리
    - `lombok-mapstruct-binding`: lombok과 mapstruct를 같이 사용할 때 발생하는 충돌을 해결하는 라이브러리
    - `commons-lang3`: 문자열이나 배열 등 자주 사용하는 기능을 구현한 유틸성 라이브러리

  - 제거된 라이브러리
    - `tomcat-embed-jasper`: 필요없는 라이브러리라서 회의때 제거하기로함

## 기타
- Paging
  - 컨트롤러마다 기본값이 다른데 어떻게 해결할 것인가?
  - Sorting Type은 어떻게 중복을 제거할 수 있는가?
> 핸들러 메서드에 page, size 파라미터 지우고 `CustomPageRequest pageRequest`를 추가해서 사용할 수 있습니다.