### PR TITLE
[FE] Post Page 레이아웃 구현

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -6,6 +6,7 @@ import Navigator from './components/organisms/Navigator';
 import PostList from './components/templates/PostList';
 import Sidebar from './components/organisms/Sidebar';
 import SeriseList from './components/templates/SeriesList';
+import PostPage from './components/templates/PostPage';
 
 const App = () => {
   return (
@@ -17,6 +18,7 @@ const App = () => {
         <Routes>
           <Route path="/signin" element={<Signin />} />
           <Route path="/posts" element={<PostList />} />
+          <Route path="/posts/:id" element={<PostPage />} />
           <Route path="/series" element={<SeriseList />} />
         </Routes>
       </BrowserRouter>

--- a/client/src/components/molecules/PostHeader.js
+++ b/client/src/components/molecules/PostHeader.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 const Container = styled.div`
   display: flex;
   flex-direction: column;
-  width: inherit;
+  width: 994px;
   height: 80px;
   margin-bottom: 13px;
 `;

--- a/client/src/components/molecules/PostHeader.js
+++ b/client/src/components/molecules/PostHeader.js
@@ -1,0 +1,20 @@
+import styled from 'styled-components';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: inherit;
+  height: 80px;
+  margin-bottom: 13px;
+`;
+
+const PostHeader = () => {
+  return (
+    <Container>
+      <h1>Title</h1>
+      <h2>Description</h2>
+    </Container>
+  );
+};
+
+export default PostHeader;

--- a/client/src/components/molecules/PostUserInfo.js
+++ b/client/src/components/molecules/PostUserInfo.js
@@ -1,0 +1,23 @@
+import styled from 'styled-components';
+
+const Container = styled.div`
+  display: flex;
+  width: inherit;
+  height: 46px;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const PostUserInfo = () => {
+  return (
+    <Container>
+      <div>작성자 어쩌구저쩌구</div>
+      <div>
+        <button type="button">버튼</button>
+        <button type="button">버튼</button>
+      </div>
+    </Container>
+  );
+};
+
+export default PostUserInfo;

--- a/client/src/components/molecules/PostUserInfo.js
+++ b/client/src/components/molecules/PostUserInfo.js
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 const Container = styled.div`
   display: flex;
-  width: inherit;
+  width: 994px;
   height: 46px;
   justify-content: space-between;
   align-items: center;

--- a/client/src/components/molecules/comments/Comment.js
+++ b/client/src/components/molecules/comments/Comment.js
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+
+const Container = styled.div`
+  display: flex;
+  width: inherit;
+  height: 36px;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+  background-color: floralwhite;
+`;
+
+const Comment = () => {
+  return (
+    <Container>
+      <div>작성자</div>
+      <div>댓글 어쩌구</div>
+      <div>
+        <button type="button">Edit</button>
+        <button type="button">Delete</button>
+      </div>
+    </Container>
+  );
+};
+
+export default Comment;

--- a/client/src/components/molecules/comments/CommentContentsContainer.js
+++ b/client/src/components/molecules/comments/CommentContentsContainer.js
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+import Comment from './Comment';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: inherit;
+  background-color: darkmagenta;
+`;
+
+const CommentContentsContainer = () => {
+  return (
+    <Container>
+      <Comment />
+      <Comment />
+      <Comment />
+      <Comment />
+    </Container>
+  );
+};
+
+export default CommentContentsContainer;

--- a/client/src/components/molecules/comments/CommentHeader.js
+++ b/client/src/components/molecules/comments/CommentHeader.js
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+const Container = styled.div`
+  display: flex;
+  width: inherit;
+  height: 30px;
+  align-items: center;
+  background-color: cadetblue;
+`;
+
+const CommentHeader = () => {
+  return <Container>총 댓글</Container>;
+};
+
+export default CommentHeader;

--- a/client/src/components/molecules/comments/CommentInputContainer.js
+++ b/client/src/components/molecules/comments/CommentInputContainer.js
@@ -1,0 +1,21 @@
+import styled from 'styled-components';
+
+const Container = styled.div`
+  display: flex;
+  width: inherit;
+  height: 60px;
+  justify-content: space-between;
+  align-items: center;
+  background-color: chartreuse;
+`;
+
+const CommentInputContainer = () => {
+  return (
+    <Container>
+      <input />
+      <button type="button">ADD</button>
+    </Container>
+  );
+};
+
+export default CommentInputContainer;

--- a/client/src/components/organisms/posts/PostCommentContainer.js
+++ b/client/src/components/organisms/posts/PostCommentContainer.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import CommentHeader from '../../molecules/comments/CommentHeader';
+import CommentInputContainer from '../../molecules/comments/CommentInputContainer';
 
 const Container = styled.div`
   display: flex;
@@ -13,6 +14,7 @@ const PostCommentContainer = () => {
   return (
     <Container>
       <CommentHeader />
+      <CommentInputContainer />
     </Container>
   );
 };

--- a/client/src/components/organisms/posts/PostCommentContainer.js
+++ b/client/src/components/organisms/posts/PostCommentContainer.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import CommentContentsContainer from '../../molecules/comments/CommentContentsContainer';
 import CommentHeader from '../../molecules/comments/CommentHeader';
 import CommentInputContainer from '../../molecules/comments/CommentInputContainer';
 
@@ -6,7 +7,6 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   width: 874px;
-  height: 300px;
   background-color: blanchedalmond;
 `;
 
@@ -15,6 +15,7 @@ const PostCommentContainer = () => {
     <Container>
       <CommentHeader />
       <CommentInputContainer />
+      <CommentContentsContainer />
     </Container>
   );
 };

--- a/client/src/components/organisms/posts/PostCommentContainer.js
+++ b/client/src/components/organisms/posts/PostCommentContainer.js
@@ -1,0 +1,20 @@
+import styled from 'styled-components';
+import CommentHeader from '../../molecules/comments/CommentHeader';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 874px;
+  height: 300px;
+  background-color: blanchedalmond;
+`;
+
+const PostCommentContainer = () => {
+  return (
+    <Container>
+      <CommentHeader />
+    </Container>
+  );
+};
+
+export default PostCommentContainer;

--- a/client/src/components/organisms/posts/PostContent.js
+++ b/client/src/components/organisms/posts/PostContent.js
@@ -6,6 +6,7 @@ const Container = styled.div`
   width: 874px;
   height: 500px;
   gap: 10px;
+  margin-bottom: 72px;
   background-color: lightpink;
 `;
 

--- a/client/src/components/organisms/posts/PostContent.js
+++ b/client/src/components/organisms/posts/PostContent.js
@@ -1,0 +1,16 @@
+import styled from 'styled-components';
+
+const Container = styled.div`
+  box-sizing: border-box;
+  display: flex;
+  width: 874px;
+  height: 500px;
+  gap: 10px;
+  background-color: lightpink;
+`;
+
+const PostContent = () => {
+  return <Container>가나다라마바사아</Container>;
+};
+
+export default PostContent;

--- a/client/src/components/organisms/posts/PostHeaderContainer.js
+++ b/client/src/components/organisms/posts/PostHeaderContainer.js
@@ -3,6 +3,7 @@ import PostHeader from '../../molecules/PostHeader';
 import PostUserInfo from '../../molecules/PostUserInfo';
 
 const Container = styled.div`
+  box-sizing: border-box;
   display: flex;
   width: 1056px;
   height: 193px;

--- a/client/src/components/organisms/posts/PostHeaderContainer.js
+++ b/client/src/components/organisms/posts/PostHeaderContainer.js
@@ -1,13 +1,14 @@
 import styled from 'styled-components';
+import PostHeader from '../../molecules/PostHeader';
+import PostUserInfo from '../../molecules/PostUserInfo';
 
 const Container = styled.div`
   display: flex;
-  width: inherit;
   width: 1056px;
   height: 193px;
   margin: 0 auto;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: center;
   padding: 29px 31px;
   gap: 10px;
   background-color: aqua;
@@ -16,9 +17,8 @@ const Container = styled.div`
 const PostHeaderContainer = () => {
   return (
     <Container>
-      <h1>Title</h1>
-      <h2>Description</h2>
-      <div>작성자 어쩌구저쩌구</div>
+      <PostHeader />
+      <PostUserInfo />
     </Container>
   );
 };

--- a/client/src/components/organisms/posts/PostHeaderContainer.js
+++ b/client/src/components/organisms/posts/PostHeaderContainer.js
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+
+const Container = styled.div`
+  display: flex;
+  width: inherit;
+  width: 1056px;
+  height: 193px;
+  margin: 0 auto;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 29px 31px;
+  gap: 10px;
+  background-color: aqua;
+`;
+
+const PostHeaderContainer = () => {
+  return (
+    <Container>
+      <h1>Title</h1>
+      <h2>Description</h2>
+      <div>작성자 어쩌구저쩌구</div>
+    </Container>
+  );
+};
+
+export default PostHeaderContainer;

--- a/client/src/components/organisms/posts/PostSubHeaderContainer.js
+++ b/client/src/components/organisms/posts/PostSubHeaderContainer.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
 const Container = styled.div`
+  box-sizing: border-box;
   display: flex;
   width: 1056px;
   height: 100px;

--- a/client/src/components/organisms/posts/PostSubHeaderContainer.js
+++ b/client/src/components/organisms/posts/PostSubHeaderContainer.js
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+
+const Container = styled.div`
+  display: flex;
+  width: 1056px;
+  height: 100px;
+  margin: 0 auto;
+  justify-content: space-between;
+  align-items: center;
+  padding: 29px 31px;
+  gap: 10px;
+  background-color: lightgreen;
+`;
+
+const PostSubHeaderContainer = () => {
+  return (
+    <Container>
+      <div>Index</div>
+      <button type="button">Add</button>
+    </Container>
+  );
+};
+
+export default PostSubHeaderContainer;

--- a/client/src/components/templates/PostPage.js
+++ b/client/src/components/templates/PostPage.js
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import PostHeaderContainer from '../organisms/posts/PostHeaderContainer';
 import PostSubHeaderContainer from '../organisms/posts/PostSubHeaderContainer';
 import PostContent from '../organisms/posts/PostContent';
+import PostCommentContainer from '../organisms/posts/PostCommentContainer';
 
 const Container = styled.div`
   display: flex;
@@ -19,6 +20,7 @@ const PostPage = () => {
       <PostHeaderContainer />
       <PostSubHeaderContainer />
       <PostContent />
+      <PostCommentContainer />
     </Container>
   );
 };

--- a/client/src/components/templates/PostPage.js
+++ b/client/src/components/templates/PostPage.js
@@ -1,0 +1,23 @@
+import styled from 'styled-components';
+import PostHeaderContainer from '../organisms/posts/PostHeaderContainer';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 1056px;
+  margin: 0 auto;
+  padding-top: 100px;
+  justify-content: center;
+  align-items: center;
+`;
+
+const PostPage = () => {
+  return (
+    <Container>
+      <PostHeaderContainer />
+      <div>asdfasdf</div>
+    </Container>
+  );
+};
+
+export default PostPage;

--- a/client/src/components/templates/PostPage.js
+++ b/client/src/components/templates/PostPage.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import PostHeaderContainer from '../organisms/posts/PostHeaderContainer';
 import PostSubHeaderContainer from '../organisms/posts/PostSubHeaderContainer';
+import PostContent from '../organisms/posts/PostContent';
 
 const Container = styled.div`
   display: flex;
@@ -17,7 +18,7 @@ const PostPage = () => {
     <Container>
       <PostHeaderContainer />
       <PostSubHeaderContainer />
-      <div>asdfasdf</div>
+      <PostContent />
     </Container>
   );
 };

--- a/client/src/components/templates/PostPage.js
+++ b/client/src/components/templates/PostPage.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import PostHeaderContainer from '../organisms/posts/PostHeaderContainer';
+import PostSubHeaderContainer from '../organisms/posts/PostSubHeaderContainer';
 
 const Container = styled.div`
   display: flex;
@@ -15,6 +16,7 @@ const PostPage = () => {
   return (
     <Container>
       <PostHeaderContainer />
+      <PostSubHeaderContainer />
       <div>asdfasdf</div>
     </Container>
   );


### PR DESCRIPTION
## Post Page 레이아웃 구현
- Post Header, Index, Body, Comment 컴포넌트 분리
- Comment 컴포넌트 molecules로 추가
## 미리보기
<img width="1132" alt="스크린샷 2023-01-11 오전 11 13 43" src="https://user-images.githubusercontent.com/110910408/211702028-a80d42b3-2be8-4228-9a76-f7f26f0abd28.png">

closed #40 