### PR TITLE
[Category] Service 1차, Controller 2차, Mapper 구현

### DIFF
--- a/server/src/main/java/com/codestates/hobby/domain/category/controller/CategoryController.java
+++ b/server/src/main/java/com/codestates/hobby/domain/category/controller/CategoryController.java
@@ -10,7 +10,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.codestates.hobby.domain.category.dto.CategoryDto;
 import com.codestates.hobby.domain.category.entity.Category;
+import com.codestates.hobby.domain.category.mapper.CategoryMapper;
 import com.codestates.hobby.domain.category.service.CategoryService;
 import com.codestates.hobby.global.dto.MultiResponseDto;
 
@@ -21,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/categories")
 public class CategoryController {
 	private final CategoryService categoryService;
+	private final CategoryMapper mapper;
 
 	// 카테고리 그룹 목록을 조회한다.
 	@GetMapping("/groups")
@@ -44,6 +47,7 @@ public class CategoryController {
 	}
 
 	private MultiResponseDto<?> toResponseDto(List<Category> categories) {
-		return new MultiResponseDto<>(new PageImpl<>(categories));
+		List<CategoryDto.Response> responses = mapper.categoriesToResponses(categories);
+		return new MultiResponseDto<>(new PageImpl<>(responses));
 	}
 }

--- a/server/src/main/java/com/codestates/hobby/domain/category/controller/CategoryController.java
+++ b/server/src/main/java/com/codestates/hobby/domain/category/controller/CategoryController.java
@@ -1,5 +1,8 @@
 package com.codestates.hobby.domain.category.controller;
 
+import java.util.List;
+
+import org.springframework.data.domain.PageImpl;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -7,27 +10,40 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.codestates.hobby.domain.category.entity.Category;
+import com.codestates.hobby.domain.category.service.CategoryService;
+import com.codestates.hobby.global.dto.MultiResponseDto;
+
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/categories")
 public class CategoryController {
+	private final CategoryService categoryService;
+
 	// 카테고리 그룹 목록을 조회한다.
 	@GetMapping("/groups")
 	public ResponseEntity<?> getGroups() {
-		return new ResponseEntity<>(HttpStatus.OK);
+		List<Category> groups = categoryService.findAllGroups();
+		return new ResponseEntity<>(toResponseDto(groups), HttpStatus.OK);
 	}
 
 	// 특정 그룹의 카테고리 목록을 조회한다.
 	@GetMapping("/groups/{group}")
 	public ResponseEntity<?> getCategories(@PathVariable String group) {
-		return new ResponseEntity<>(HttpStatus.OK);
+		List<Category> categories = categoryService.findAllByGroup(group);
+		return new ResponseEntity<>(toResponseDto(categories), HttpStatus.OK);
 	}
 
 	// 모든 카테고리 목록을 조회한다.
 	@GetMapping
 	public ResponseEntity<?> getAll() {
-		return new ResponseEntity<>(HttpStatus.OK);
+		List<Category> categories = categoryService.findAll();
+		return new ResponseEntity<>(toResponseDto(categories), HttpStatus.OK);
+	}
+
+	private MultiResponseDto<?> toResponseDto(List<Category> categories) {
+		return new MultiResponseDto<>(new PageImpl<>(categories));
 	}
 }

--- a/server/src/main/java/com/codestates/hobby/domain/category/dto/CategoryDto.java
+++ b/server/src/main/java/com/codestates/hobby/domain/category/dto/CategoryDto.java
@@ -14,8 +14,6 @@ public class CategoryDto {
 		private long id;
 		private String korName;
 		private String engName;
-		private boolean isGroup;
-		private Response group;	// entity -> dto 매핑할 때 순환참조 조심해야됨
 		private List<Response> categories;
 	}
 }

--- a/server/src/main/java/com/codestates/hobby/domain/category/entity/Category.java
+++ b/server/src/main/java/com/codestates/hobby/domain/category/entity/Category.java
@@ -35,11 +35,11 @@ public class Category {
 	private String engName;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "parent_id")
-	private Category parent;
+	@JoinColumn(name = "group_id")
+	private Category group;
 
-	@OneToMany(mappedBy = "parent")
-	private List<Category> children;
+	@OneToMany(mappedBy = "group")
+	private List<Category> categories;
 
 	@OneToMany(mappedBy = "category")
 	private List<Series> series;
@@ -50,10 +50,10 @@ public class Category {
 	@OneToMany(mappedBy = "category")
 	private List<Showcase> showcases;
 
-	private Category(String korName, String engName, Category parent) {
+	private Category(String korName, String engName, Category group) {
 		this.korName = korName;
 		this.engName = engName;
-		this.parent = parent;
+		this.group = group;
 	}
 
 	public static Category createParent(String korName, String engName) {
@@ -64,7 +64,7 @@ public class Category {
 		return new Category(korName, engName, parent);
 	}
 
-	public boolean isParent() {
-		return parent != null;
+	public boolean isGroup() {
+		return group != null;
 	}
 }

--- a/server/src/main/java/com/codestates/hobby/domain/category/entity/Category.java
+++ b/server/src/main/java/com/codestates/hobby/domain/category/entity/Category.java
@@ -1,6 +1,5 @@
 package com.codestates.hobby.domain.category.entity;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.persistence.Column;
@@ -30,7 +29,10 @@ public class Category {
 	private Long id;
 
 	@Column(nullable = false, unique = true)
-	private String name;
+	private String korName;
+
+	@Column(nullable = false, unique = true)
+	private String engName;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "parent_id")
@@ -48,17 +50,18 @@ public class Category {
 	@OneToMany(mappedBy = "category")
 	private List<Showcase> showcases;
 
-	private Category(String name, Category parent) {
-		this.name = name;
+	private Category(String korName, String engName, Category parent) {
+		this.korName = korName;
+		this.engName = engName;
 		this.parent = parent;
 	}
 
-	public static Category createParent(String name) {
-		return new Category(name, null);
+	public static Category createParent(String korName, String engName) {
+		return new Category(korName, engName, null);
 	}
 
-	public static Category createChild(String name, Category parent) {
-		return new Category(name, parent);
+	public static Category createChild(String korName, String engName, Category parent) {
+		return new Category(korName, engName, parent);
 	}
 
 	public boolean isParent() {

--- a/server/src/main/java/com/codestates/hobby/domain/category/mapper/CategoryMapper.java
+++ b/server/src/main/java/com/codestates/hobby/domain/category/mapper/CategoryMapper.java
@@ -1,0 +1,15 @@
+package com.codestates.hobby.domain.category.mapper;
+
+import java.util.List;
+
+import org.mapstruct.Mapper;
+
+import com.codestates.hobby.domain.category.dto.CategoryDto;
+import com.codestates.hobby.domain.category.entity.Category;
+
+@Mapper(componentModel = "spring")
+public interface CategoryMapper {
+	CategoryDto.Response categoryToResponse(Category category);
+
+	List<CategoryDto.Response> categoriesToResponses(List<Category> categories);
+}

--- a/server/src/main/java/com/codestates/hobby/domain/category/service/CategoryService.java
+++ b/server/src/main/java/com/codestates/hobby/domain/category/service/CategoryService.java
@@ -1,0 +1,31 @@
+package com.codestates.hobby.domain.category.service;
+
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.codestates.hobby.domain.category.entity.Category;
+
+@Service
+@Transactional(readOnly = true)
+public class CategoryService {
+	public Category findById(long categoryId) {
+		return null;
+	}
+
+	public Category findByName(String categoryName) {
+		return null;
+	}
+
+	public Page<Category> findAll(int page, int size) {
+		return null;
+	}
+
+	public Page<Category> findAllByGroup(String group, int page, int size) {
+		return null;
+	}
+
+	public Page<Category> findAllGroups(int page, int size) {
+		return null;
+	}
+}

--- a/server/src/main/java/com/codestates/hobby/domain/category/service/CategoryService.java
+++ b/server/src/main/java/com/codestates/hobby/domain/category/service/CategoryService.java
@@ -1,6 +1,7 @@
 package com.codestates.hobby.domain.category.service;
 
-import org.springframework.data.domain.Page;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,15 +18,15 @@ public class CategoryService {
 		return null;
 	}
 
-	public Page<Category> findAll(int page, int size) {
+	public List<Category> findAll() {
 		return null;
 	}
 
-	public Page<Category> findAllByGroup(String group, int page, int size) {
+	public List<Category> findAllByGroup(String group) {
 		return null;
 	}
 
-	public Page<Category> findAllGroups(int page, int size) {
+	public List<Category> findAllGroups() {
 		return null;
 	}
 }

--- a/server/src/test/java/com/codestates/hobby/domain/category/controller/CategoryControllerTest.java
+++ b/server/src/test/java/com/codestates/hobby/domain/category/controller/CategoryControllerTest.java
@@ -1,0 +1,84 @@
+package com.codestates.hobby.domain.category.controller;
+
+import static com.codestates.hobby.domain.stub.CategoryStub.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.codestates.hobby.domain.category.dto.CategoryDto;
+import com.codestates.hobby.domain.category.mapper.CategoryMapper;
+import com.codestates.hobby.domain.category.service.CategoryService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@AutoConfigureMockMvc(addFilters = false)
+@MockBean(JpaMetamodelMappingContext.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@WebMvcTest(value = CategoryController.class, excludeAutoConfiguration = SecurityAutoConfiguration.class)
+class CategoryControllerTest {
+	@Autowired
+	MockMvc mvc;
+
+	@Autowired
+	ObjectMapper om;
+
+	@MockBean
+	CategoryService service;
+
+	@MockBean
+	CategoryMapper mapper;
+
+	List<CategoryDto.Response> response;
+
+	@BeforeAll
+	void beforeAll() {
+		response = List.of(groupResponse());
+	}
+
+	@Test
+	void getGroups() throws Exception {
+		// given
+		given(service.findAllGroups()).willReturn(List.of());
+		given(mapper.categoriesToResponses(anyList())).willReturn(response);
+
+		// when
+		ResultActions actions = mvc.perform(get("/categories/groups"));
+
+		// then
+		actions
+			.andDo(print())
+			.andExpect(status().isOk());
+	}
+
+	@Test
+	void getCategories() throws Exception {
+		// given
+
+		// when
+
+		// then
+	}
+
+	@Test
+	void getAll() throws Exception {
+		// given
+
+		// when
+
+		// then
+	}
+}

--- a/server/src/test/java/com/codestates/hobby/domain/category/service/CategoryServiceTest.java
+++ b/server/src/test/java/com/codestates/hobby/domain/category/service/CategoryServiceTest.java
@@ -1,0 +1,30 @@
+package com.codestates.hobby.domain.category.service;
+
+import org.junit.jupiter.api.Test;
+
+class CategoryServiceTest {
+	@Test
+	void 아이디로_조회한다() {
+
+	}
+
+	@Test
+	void 이름으로_조회한다() {
+
+	}
+
+	@Test
+	void 전체를_조회한다() {
+
+	}
+
+	@Test
+	void 그룹이름으로_조회한다() {
+
+	}
+
+	@Test
+	void 그룹목록을_조회한다() {
+
+	}
+}

--- a/server/src/test/java/com/codestates/hobby/domain/stub/CategoryStub.java
+++ b/server/src/test/java/com/codestates/hobby/domain/stub/CategoryStub.java
@@ -1,0 +1,27 @@
+package com.codestates.hobby.domain.stub;
+
+import java.util.List;
+
+import com.codestates.hobby.domain.category.dto.CategoryDto;
+
+public class CategoryStub {
+	public static CategoryDto.Response groupResponse() {
+		CategoryDto.Response group = new CategoryDto.Response();
+		CategoryDto.Response cat1 = new CategoryDto.Response();
+		CategoryDto.Response cat2 = new CategoryDto.Response();
+
+		group.setId(1L);
+		group.setKorName("운동");
+		group.setEngName("EXERCISE");
+		group.setCategories(List.of(cat1, cat2));
+
+		cat1.setId(2L);
+		cat2.setId(3L);
+		cat1.setKorName("조깅");
+		cat2.setKorName("수영");
+		cat1.setEngName("JOGGIN");
+		cat2.setEngName("SWIMMING");
+
+		return group;
+	}
+}


### PR DESCRIPTION
## 개요
- [#33]
- [#34]
- [#35]
- [#36]

## 작업 내용
- Service 1차 구현
- Controller 클래스에 Service DI 및 메서드 호출
- Mapper 구현  및 Controller 클래스에 적용
- Service 및 Controller 테스트 케이스 작성

## 변경사항
 - DTO
    - 취미의 그룹에 대해 응답하는 상황이 없어서 group 및 isGroup 필드 제거
    - group이 ResponseDTO에 있을 경우 직렬화할 때 자기참조 때문에 SOE 예외 발생함
- Entity
    - parent -> group으로 필드명 변경
    - children -> categories로 필드명 변경
  
## 기타 
- ResponseDTO의 필드에 ResponseDTO가 있으면 자기참조가 발생합니다. `@JsonManagedReference/@JsonBackReference`를 사용해봤지만 자기참조시에는 사용하기 힘들어서 우선 group 필드를 제거했습니다.
- Category의 경우 parent 또는 chlidren보다 group, categories(또는 hobbies)가 적절할 거 같아 임시로 바꿔봤는데 더 적절한 다른 이름이 있는지 아니면 이전 이름이 괜찮은지 궁금합니다.