### PR TITLE
[FE] Page Header 컴포넌트 구현

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -5,7 +5,7 @@ import Signin from './components/templates/Signin';
 import Navigator from './components/organisms/Navigator';
 import PostList from './components/templates/PostList';
 import Showcase from './components/templates/Showcase';
-// import Sidebar from './components/organisms/Sidebar';
+import Sidebar from './components/organisms/Sidebar';
 import SeriesList from './components/templates/SeriesList';
 import GlobalStyled from './GlobalStyle';
 import PublicRoute from './routes/PublicRoute';
@@ -16,7 +16,7 @@ const App = () => {
       <Reset />
       <GlobalStyled />
       <Navigator />
-      {/* <Sidebar /> */}
+      <Sidebar />
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<PublicRoute component={<Showcase />} />} />

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -5,7 +5,7 @@ import Signin from './components/templates/Signin';
 import Navigator from './components/organisms/Navigator';
 import PostList from './components/templates/PostList';
 import Showcase from './components/templates/Showcase';
-import Sidebar from './components/organisms/Sidebar';
+// import Sidebar from './components/organisms/Sidebar';
 import SeriesList from './components/templates/SeriesList';
 import GlobalStyled from './GlobalStyle';
 import PublicRoute from './routes/PublicRoute';
@@ -16,7 +16,7 @@ const App = () => {
       <Reset />
       <GlobalStyled />
       <Navigator />
-      <Sidebar />
+      {/* <Sidebar /> */}
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<PublicRoute component={<Showcase />} />} />

--- a/client/src/components/atoms/Buttons.js
+++ b/client/src/components/atoms/Buttons.js
@@ -12,7 +12,7 @@ const WhiteButton = styled.a`
   border: 1px solid var(--gray-600);
   text-decoration: none;
   font-size: var(--label-l);
-  font-weight: 500;
+  font-weight: 600;
   color: black;
 
   &:visited {
@@ -40,18 +40,18 @@ const OrangeButton = styled(WhiteButton)`
 `;
 
 const WhiteShadowButton = styled(WhiteButton)`
-  box-shadow: var(--boxShadow-02) var(--gray-700);
+  box-shadow: var(--boxShadow-00) var(--gray-700);
 `;
 
 const BlackShadowButton = styled(BlackButton)`
-  box-shadow: var(--boxShadow-02) var(--gray-600);
+  box-shadow: var(--boxShadow-00) var(--gray-600);
 `;
 
 const BlueShadowButton = styled(BlackShadowButton)`
   background-color: var(--blue-400);
   border-color: var(--blue-400);
   color: white;
-  box-shadow: var(--boxShadow-02) var(--orange-400);
+  box-shadow: var(--boxShadow-00) var(--orange-400);
 `;
 
 export { WhiteButton, BlackButton, OrangeButton, WhiteShadowButton, BlackShadowButton, BlueShadowButton };

--- a/client/src/components/organisms/PageHeader.js
+++ b/client/src/components/organisms/PageHeader.js
@@ -4,7 +4,7 @@ const Container = styled.div`
   display: flex;
   box-sizing: border-box;
   width: 100%;
-  height: 116px;
+  height: ${props => (props.width ? props.width : '116px')};
   align-items: center;
   justify-content: space-between;
   align-items: center;
@@ -20,9 +20,9 @@ const TextContainer = styled.div`
   flex-direction: column;
 `;
 
-const ListHeaderContainer = ({ headerTitle, asideHeader }) => {
+const PageHeader = ({ headerTitle, asideHeader, width }) => {
   return (
-    <Container>
+    <Container width={width}>
       <TextContainer>
         <div style={{ fontSize: 'var(--display-s)', fontWeight: '700' }}>{headerTitle}</div>
       </TextContainer>
@@ -31,4 +31,4 @@ const ListHeaderContainer = ({ headerTitle, asideHeader }) => {
   );
 };
 
-export default ListHeaderContainer;
+export default PageHeader;

--- a/client/src/components/organisms/PageHeader.js
+++ b/client/src/components/organisms/PageHeader.js
@@ -22,16 +22,18 @@ const TextContainer = styled.div`
 
 /**
  * props 설명
- * headerTitle: Header 왼쪽 타이틀
+ * headerTitle: Header 왼쪽 하단 타이틀
+ * headerSubTitle: Header 왼쪽 상단 타이틀
  * asideHeader: Header 오른쪽 추가 컴포넌트
  * height: Header 외부 컨테이너의 높이
  */
 
-const PageHeader = ({ headerTitle, asideHeader, height }) => {
+const PageHeader = ({ headerTitle, headerSubTitle, asideHeader, height }) => {
   return (
     <Container height={height}>
       <TextContainer>
-        <div style={{ fontSize: 'var(--display-s)', fontWeight: '700' }}>{headerTitle}</div>
+        <div style={{ fontSize: 'var(--label-l)', fontWeight: '500' }}>{headerSubTitle || 'Subtitle'}</div>
+        <div style={{ fontSize: 'var(--display-s)', fontWeight: '700' }}>{headerTitle || 'TITLE'}</div>
       </TextContainer>
       {asideHeader || null}
     </Container>

--- a/client/src/components/organisms/PageHeader.js
+++ b/client/src/components/organisms/PageHeader.js
@@ -4,7 +4,7 @@ const Container = styled.div`
   display: flex;
   box-sizing: border-box;
   width: 100%;
-  height: ${props => (props.width ? props.width : '116px')};
+  height: ${props => (props.height ? props.height : '116px')};
   align-items: center;
   justify-content: space-between;
   align-items: center;
@@ -20,9 +20,16 @@ const TextContainer = styled.div`
   flex-direction: column;
 `;
 
-const PageHeader = ({ headerTitle, asideHeader, width }) => {
+/**
+ * props 설명
+ * headerTitle: Header 왼쪽 타이틀
+ * asideHeader: Header 오른쪽 추가 컴포넌트
+ * height: Header 외부 컨테이너의 높이
+ */
+
+const PageHeader = ({ headerTitle, asideHeader, height }) => {
   return (
-    <Container width={width}>
+    <Container height={height}>
       <TextContainer>
         <div style={{ fontSize: 'var(--display-s)', fontWeight: '700' }}>{headerTitle}</div>
       </TextContainer>

--- a/client/src/components/organisms/listcontents/ListHeader.js
+++ b/client/src/components/organisms/listcontents/ListHeader.js
@@ -2,11 +2,19 @@ import styled from 'styled-components';
 
 const Container = styled.div`
   display: flex;
-  width: inherit;
+  box-sizing: border-box;
+  width: 100%;
   height: 116px;
-  background-color: aqua;
   align-items: center;
-  justify-content: space-around;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 60px;
+  gap: 10px;
+  border: 5px solid var(--gray-700);
+  border-radius: 15px;
+  box-shadow: var(--boxShadow-01) var(--gray-700);
+
+  margin: 500px;
 `;
 
 const ListHeaderContainer = () => {

--- a/client/src/components/organisms/listcontents/ListHeader.js
+++ b/client/src/components/organisms/listcontents/ListHeader.js
@@ -13,8 +13,6 @@ const Container = styled.div`
   border: 5px solid var(--gray-700);
   border-radius: 15px;
   box-shadow: var(--boxShadow-01) var(--gray-700);
-
-  margin: 500px;
 `;
 
 const TextContainer = styled.div`

--- a/client/src/components/organisms/listcontents/ListHeader.js
+++ b/client/src/components/organisms/listcontents/ListHeader.js
@@ -17,11 +17,18 @@ const Container = styled.div`
   margin: 500px;
 `;
 
-const ListHeaderContainer = () => {
+const TextContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const ListHeaderContainer = ({ headerTitle, asideHeader }) => {
   return (
     <Container>
-      <h1>Post In Category</h1>
-      <button type="button">Create Post</button>
+      <TextContainer>
+        <div style={{ fontSize: 'var(--display-s)', fontWeight: '700' }}>{headerTitle}</div>
+      </TextContainer>
+      {asideHeader || null}
     </Container>
   );
 };

--- a/client/src/components/templates/PostList.js
+++ b/client/src/components/templates/PostList.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import ListHeaderContainer from '../organisms/listcontents/ListHeader';
+import PageHeader from '../organisms/PageHeader';
 import FilterContainer from '../organisms/listcontents/ListFilter';
 import PaginationContainer from '../organisms/listcontents/ListPagination';
 import PostListContainer from '../organisms/listcontents/PostListContainer';
@@ -17,7 +17,7 @@ const Container = styled.div`
 const PostList = () => {
   return (
     <Container>
-      <ListHeaderContainer />
+      <PageHeader />
       <FilterContainer />
       <PostListContainer />
       <PaginationContainer />

--- a/client/src/components/templates/SeriesList.js
+++ b/client/src/components/templates/SeriesList.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import ListHeaderContainer from '../organisms/listcontents/ListHeader';
+import PageHeader from '../organisms/PageHeader';
 import FilterContainer from '../organisms/listcontents/ListFilter';
 import PaginationContainer from '../organisms/listcontents/ListPagination';
 import SeriesListContainer from '../organisms/listcontents/SeriesListContainer';
@@ -17,7 +17,7 @@ const Container = styled.div`
 const SeriesList = () => {
   return (
     <Container>
-      <ListHeaderContainer />
+      <PageHeader />
       <FilterContainer />
       <SeriesListContainer />
       <PaginationContainer />


### PR DESCRIPTION
## Page Header 컴포넌트 구현
- 외부 디자인 구현
- 내부 타이틀 및 컴포넌트 추가 기능 구현

### props 설명
 * headerTitle: Header 왼쪽 타이틀
 * headerSubTitle: Header 왼쪽 상단 타이틀
 * asideHeader: Header 오른쪽 추가 컴포넌트
 * height: Header 외부 컨테이너의 높이
### 예시
```javascript
      <PageHeader
        headerTitle="POSTS IN CATEGORY"
        headerSubTitle="Subtitle"
        asideHeader={<BlueShadowButton>Create</BlueShadowButton>}
        height="200px"
      />
```

## 미리보기
<img width="1073" alt="스크린샷 2023-01-11 오후 3 14 06" src="https://user-images.githubusercontent.com/110910408/211735337-31fe33fc-4a85-4db5-a047-af7858c4a7bc.png">
<img width="1070" alt="스크린샷 2023-01-12 오후 12 00 02" src="https://user-images.githubusercontent.com/110910408/211965684-23d295cb-764e-4589-873f-99b46504978f.png">

closes #63 