### PR TITLE
[BE] FileInfo service 구현

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -19,7 +19,7 @@ repositories {
 }
 
 dependencies {
-    // 스프링 부터
+    // 스프링 부트
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -31,6 +31,11 @@ dependencies {
     implementation 'org.mapstruct:mapstruct:1.5.3.Final'
     implementation 'org.apache.commons:commons-lang3'
     implementation 'com.google.code.gson:gson'
+
+    // 클라우드 스토리지
+    // implementation 'org.springframework.cloud:spring-cloud-gcp-starter:1.2.8.RELEASE'
+    // -> application.yml에 key 위치만 명시하면 자동설정돼서 편하지만, 잡다한 라이브러리들을 의존함
+    implementation 'org.springframework.cloud:spring-cloud-gcp-storage:1.2.8.RELEASE'
 
     runtimeOnly 'com.h2database:h2'
     compileOnly 'org.projectlombok:lombok'

--- a/server/src/main/java/com/codestates/hobby/domain/fileInfo/dto/ImageType.java
+++ b/server/src/main/java/com/codestates/hobby/domain/fileInfo/dto/ImageType.java
@@ -1,0 +1,22 @@
+package com.codestates.hobby.domain.fileInfo.dto;
+
+import java.util.Arrays;
+
+public enum ImageType {
+	PNG, JPEG, WEBP, GIF;
+
+	public String toContentType() {
+		return "image/" + name().toLowerCase();
+	}
+
+	public String getExtension() {
+		return name().toLowerCase();
+	}
+
+	public static ImageType search(String type) {
+		return Arrays.stream(ImageType.values())
+			.filter(imageType ->  type.equalsIgnoreCase(imageType.name()))
+			.findAny()
+			.orElse(null);
+	}
+}

--- a/server/src/main/java/com/codestates/hobby/domain/fileInfo/service/FileInfoService.java
+++ b/server/src/main/java/com/codestates/hobby/domain/fileInfo/service/FileInfoService.java
@@ -1,0 +1,14 @@
+package com.codestates.hobby.domain.fileInfo.service;
+
+import java.util.Map;
+import java.util.UUID;
+
+import com.codestates.hobby.domain.fileInfo.dto.ImageType;
+
+public interface FileInfoService {
+	Map<String, String> generateSignedURL(ImageType type, String basePath);
+
+	default String generateRandomFilename(ImageType type, String basePath) {
+		return String.format("%s/%s.%s", basePath, UUID.randomUUID(), type.getExtension());
+	}
+}

--- a/server/src/main/java/com/codestates/hobby/domain/fileInfo/service/GCSFileInfoService.java
+++ b/server/src/main/java/com/codestates/hobby/domain/fileInfo/service/GCSFileInfoService.java
@@ -1,0 +1,50 @@
+package com.codestates.hobby.domain.fileInfo.service;
+
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+import com.codestates.hobby.domain.fileInfo.dto.ImageType;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.HttpMethod;
+import com.google.cloud.storage.Storage;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Profile("gcs")
+@RequiredArgsConstructor
+public class GCSFileInfoService implements FileInfoService {
+	private final Storage storage;
+
+	@Value("${cloud.storage.gcs.bucket-name:intorest-imgaes}")
+	private String bucketName;
+
+	@Override
+	public Map<String, String> generateSignedURL(ImageType imageType, String basePath) {
+		String savedFilename = generateRandomFilename(imageType, basePath);
+		BlobInfo blobInfo = BlobInfo.newBuilder(BlobId.of(bucketName, savedFilename)).build();
+		Map<String, String> headers = Collections.singletonMap("Content-Type", imageType.toContentType());
+
+		URL url = storage.signUrl(
+			blobInfo,
+			15,
+			TimeUnit.MINUTES,
+			Storage.SignUrlOption.httpMethod(HttpMethod.PUT),
+			Storage.SignUrlOption.withExtHeaders(headers),
+			Storage.SignUrlOption.withV4Signature());
+
+		Map<String, String> result = new HashMap<>();
+		result.put("url", url.toString());
+		result.put("path", String.join("/", bucketName, savedFilename));
+
+		return result;
+	}
+}

--- a/server/src/main/java/com/codestates/hobby/domain/fileInfo/service/S3FileInfoService.java
+++ b/server/src/main/java/com/codestates/hobby/domain/fileInfo/service/S3FileInfoService.java
@@ -1,0 +1,22 @@
+package com.codestates.hobby.domain.fileInfo.service;
+
+import java.util.Map;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+import com.codestates.hobby.domain.fileInfo.dto.ImageType;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Profile("aws")
+@RequiredArgsConstructor
+public class S3FileInfoService implements FileInfoService {
+	// https://docs.aws.amazon.com/ko_kr/AmazonS3/latest/userguide/ShareObjectPreSignedURL.html
+
+	@Override
+	public Map<String, String> generateSignedURL(ImageType type, String basePath) {
+		return null;
+	}
+}

--- a/server/src/main/java/com/codestates/hobby/global/config/GCSConfig.java
+++ b/server/src/main/java/com/codestates/hobby/global/config/GCSConfig.java
@@ -18,7 +18,7 @@ public class GCSConfig {
 		GoogleCredentials credentials =
 			GoogleCredentials.fromStream(getClass().getResourceAsStream("/intorest-ea8d5b9d1484.json"));
 
-		return StorageOptions.newBuilder().setProjectId("nosell")
+		return StorageOptions.newBuilder().setProjectId("intorest")
 			.setCredentials(credentials)
 			.build().getService();
 	}

--- a/server/src/main/java/com/codestates/hobby/global/config/GCSConfig.java
+++ b/server/src/main/java/com/codestates/hobby/global/config/GCSConfig.java
@@ -1,0 +1,25 @@
+package com.codestates.hobby.global.config;
+
+import java.io.IOException;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+
+@Profile("gcs")
+@Configuration
+public class GCSConfig {
+	@Bean
+	public Storage storage() throws IOException {
+		GoogleCredentials credentials =
+			GoogleCredentials.fromStream(getClass().getResourceAsStream("/intorest-ea8d5b9d1484.json"));
+
+		return StorageOptions.newBuilder().setProjectId("nosell")
+			.setCredentials(credentials)
+			.build().getService();
+	}
+}


### PR DESCRIPTION
## 개요
- [#33 ]

## 작업내용
- `FileInfoService`의 `genereteURL` 메서드를 실행하기 위해서는 다음과 같은 파라미터가 필요합니다.
  - `contentType` (ex. `image/png`, image/webp`...)
  - `basePath`: 클라우드 스토리지의 버킷에 저장될 경로
- 메서드의 결과는 Map 형태로 두 가지의 String을 가지고 있습니다.
  - `url`: 클라우드 저장소에 이미지를 저장하기 위한 url
  - `savedFilename`: 버켓에 저장될 이미지의 위치
- 위의 정보로 클라이언트가 업로드하는 방법
  - `curl -X PUT -H 'Content-Type: {image/png}' --upload-file {my-file} {url}`

## 기타
- 메서드의 반환타입이 Map이라 호출하는 쪽에서 키값을 알아야해서 불편할수도 있는데 FileInfoDTO를 만들까요??

**해당 기능을 이용하기 위해서는 반드시 GCP의 사용자 키 파일이 필요합니다**
