### PR TITLE
[FE/Search] 페이지 레이아웃 구현

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -12,6 +12,8 @@ import User from './components/templates/User';
 import UserEdit from './components/templates/UserEdit';
 import SeriesList from './components/templates/SeriesList';
 import PostPage from './components/templates/PostPage';
+import Search from './components/templates/Search';
+
 import GlobalStyled from './GlobalStyle';
 import PublicRoute from './routes/PublicRoute';
 
@@ -32,6 +34,7 @@ const App = () => {
             <Route path="/series" element={<PublicRoute component={<SeriesList />} />} />
             <Route path="/user" element={<PublicRoute component={<User />} />} />
             <Route path="/user/edit" element={<PublicRoute component={<UserEdit />} />} />
+            <Route path="/search/:keyword" element={<PublicRoute component={<Search />} />} />
           </Routes>
         </BrowserRouter>
       </Main>

--- a/client/src/components/organisms/search/SearchResultTitle.js
+++ b/client/src/components/organisms/search/SearchResultTitle.js
@@ -1,0 +1,41 @@
+import styled from 'styled-components';
+
+const SearchResultTitle = ({ title, amount, moreBtn }) => {
+  return (
+    <Container>
+      <HeaderContainer>
+        <Header>{title}</Header>
+        <ResultCount>{amount} 건</ResultCount>
+      </HeaderContainer>
+      {moreBtn ? <button type="button"> 더보기 </button> : null}
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  display: flex;
+  width: 100%;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid black;
+  padding-bottom: 10px;
+  margin-bottom: 15px;
+  background-color: yellow;
+`;
+
+const HeaderContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+`;
+
+const Header = styled.div`
+  font-size: var(--heading-s);
+`;
+
+const ResultCount = styled.div`
+  font-size: var(--label-l);
+`;
+
+export default SearchResultTitle;

--- a/client/src/components/templates/Search.js
+++ b/client/src/components/templates/Search.js
@@ -1,0 +1,32 @@
+import styled from 'styled-components';
+import ListHeaderContainer from '../organisms/listcontents/ListHeader';
+import FilterContainer from '../organisms/listcontents/ListFilter';
+import PaginationContainer from '../organisms/listcontents/ListPagination';
+import SeriesListContainer from '../organisms/listcontents/SeriesListContainer';
+import SearchResultTitle from '../organisms/search/SearchResultTitle';
+import PostListContainer from '../organisms/listcontents/PostListContainer';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Search = () => {
+  return (
+    <Container>
+      <ListHeaderContainer />
+      <SearchResultTitle title="검색결과" amount="120" />
+      <FilterContainer />
+      <SearchResultTitle title="Post" amount="60" />
+      <PostListContainer />
+      <SearchResultTitle title="Series" amount="60" />
+      <SeriesListContainer />
+      <PaginationContainer />
+    </Container>
+  );
+};
+
+export default Search;


### PR DESCRIPTION
## 개요
- #51 

## 작업내용
- Search 페이지 구성 컴포넌트 추가
- Search 템플릿 추가

## 미리보기
![image](https://user-images.githubusercontent.com/67799687/211949491-80df3d7e-4ac8-4589-b766-3cf69361610c.png)
![image](https://user-images.githubusercontent.com/67799687/211949514-de42e368-8990-437a-aecc-9854f85b5616.png)

close #51 