### PR TITLE
[BE/FileInfo] Controller 구현 및 리펙토링

### DIFF
--- a/server/src/main/java/com/codestates/hobby/domain/fileInfo/controller/FileInfoController.java
+++ b/server/src/main/java/com/codestates/hobby/domain/fileInfo/controller/FileInfoController.java
@@ -1,0 +1,32 @@
+package com.codestates.hobby.domain.fileInfo.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.codestates.hobby.domain.fileInfo.dto.BasePath;
+import com.codestates.hobby.domain.fileInfo.dto.ImageType;
+import com.codestates.hobby.domain.fileInfo.dto.SignedURL;
+import com.codestates.hobby.domain.fileInfo.service.FileInfoService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/{base-path}")
+public class FileInfoController {
+	private final FileInfoService fileInfoService;
+
+	@PostMapping("/files")
+	public ResponseEntity<?> generateURL(@PathVariable("base-path") BasePath basePath, @RequestBody ImageType type) {
+		SignedURL signedURL = fileInfoService.generateSignedURL(type, basePath);
+
+		return new ResponseEntity<>(signedURL, HttpStatus.CREATED);
+	}
+}

--- a/server/src/main/java/com/codestates/hobby/domain/fileInfo/dto/BasePath.java
+++ b/server/src/main/java/com/codestates/hobby/domain/fileInfo/dto/BasePath.java
@@ -1,0 +1,10 @@
+package com.codestates.hobby.domain.fileInfo.dto;
+
+public enum BasePath {
+	POSTS, SERIES, SHOWCASES;
+
+	@Override
+	public String toString() {
+		return name().toLowerCase();
+	}
+}

--- a/server/src/main/java/com/codestates/hobby/domain/fileInfo/dto/BasePath.java
+++ b/server/src/main/java/com/codestates/hobby/domain/fileInfo/dto/BasePath.java
@@ -1,7 +1,7 @@
 package com.codestates.hobby.domain.fileInfo.dto;
 
 public enum BasePath {
-	POSTS, SERIES, SHOWCASES;
+	POSTS, SERIES, SHOWCASES, MEMBERS;
 
 	@Override
 	public String toString() {

--- a/server/src/main/java/com/codestates/hobby/domain/fileInfo/dto/FileInfoDto.java
+++ b/server/src/main/java/com/codestates/hobby/domain/fileInfo/dto/FileInfoDto.java
@@ -1,0 +1,12 @@
+package com.codestates.hobby.domain.fileInfo.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class FileInfoDto {
+	@Getter
+	@NoArgsConstructor
+	public static class Post {
+		private ImageType type;
+	}
+}

--- a/server/src/main/java/com/codestates/hobby/domain/fileInfo/dto/ImageType.java
+++ b/server/src/main/java/com/codestates/hobby/domain/fileInfo/dto/ImageType.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum ImageType {
-	PNG, JPEG, WEBP, GIF;
+	PNG, JPEG, JPG, WEBP, GIF;
 
 	private final String lowerCase;
 

--- a/server/src/main/java/com/codestates/hobby/domain/fileInfo/dto/ImageType.java
+++ b/server/src/main/java/com/codestates/hobby/domain/fileInfo/dto/ImageType.java
@@ -2,21 +2,34 @@ package com.codestates.hobby.domain.fileInfo.dto;
 
 import java.util.Arrays;
 
+import org.springframework.web.server.UnsupportedMediaTypeStatusException;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public enum ImageType {
 	PNG, JPEG, WEBP, GIF;
 
-	public String toContentType() {
-		return "image/" + name().toLowerCase();
+	private final String lowerCase;
+
+	ImageType() {
+		this.lowerCase = name().toLowerCase();
 	}
 
 	public String getExtension() {
-		return name().toLowerCase();
+		return lowerCase;
 	}
 
+	@JsonValue
+	public String toContentType() {
+		return "image/" + lowerCase;
+	}
+
+	@JsonCreator
 	public static ImageType search(String type) {
 		return Arrays.stream(ImageType.values())
-			.filter(imageType ->  type.equalsIgnoreCase(imageType.name()))
+			.filter(imageType -> type.equalsIgnoreCase(imageType.name()))
 			.findAny()
-			.orElse(null);
+			.orElseThrow(() -> new UnsupportedMediaTypeStatusException("Unsupported media type for " + type));
 	}
 }

--- a/server/src/main/java/com/codestates/hobby/domain/fileInfo/dto/SignedURL.java
+++ b/server/src/main/java/com/codestates/hobby/domain/fileInfo/dto/SignedURL.java
@@ -8,4 +8,5 @@ import lombok.Getter;
 public class SignedURL {
 	private String signedURL;
 	private String fileURL;
+	private ImageType type;
 }

--- a/server/src/main/java/com/codestates/hobby/domain/fileInfo/service/FileInfoService.java
+++ b/server/src/main/java/com/codestates/hobby/domain/fileInfo/service/FileInfoService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import com.codestates.hobby.domain.fileInfo.dto.BasePath;
 import com.codestates.hobby.domain.fileInfo.dto.ImageType;
 import com.codestates.hobby.domain.fileInfo.dto.SignedURL;
 import com.codestates.hobby.domain.fileInfo.entity.FileInfo;
@@ -16,7 +17,7 @@ public abstract class FileInfoService {
 		this.fileInfoRepository = fileInfoRepository;
 	}
 
-	abstract public SignedURL generateSignedURL(ImageType type, String basePath);
+	abstract public SignedURL generateSignedURL(ImageType type, BasePath basePath);
 
 	abstract public void delete(List<FileInfo> fileInfos);
 

--- a/server/src/main/java/com/codestates/hobby/domain/fileInfo/service/GCSFileInfoService.java
+++ b/server/src/main/java/com/codestates/hobby/domain/fileInfo/service/GCSFileInfoService.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
+import com.codestates.hobby.domain.fileInfo.dto.BasePath;
 import com.codestates.hobby.domain.fileInfo.dto.ImageType;
 import com.codestates.hobby.domain.fileInfo.dto.SignedURL;
 import com.codestates.hobby.domain.fileInfo.entity.FileInfo;
@@ -39,8 +40,8 @@ public class GCSFileInfoService extends FileInfoService {
 	}
 
 	@Override
-	public SignedURL generateSignedURL(ImageType imageType, String basePath) {
-		String savedFilename = generateRandomFilename(imageType, basePath);
+	public SignedURL generateSignedURL(ImageType imageType, BasePath basePath) {
+		String savedFilename = generateRandomFilename(imageType, basePath.toString());
 		BlobInfo blobInfo = BlobInfo.newBuilder(BlobId.of(bucketName, savedFilename)).build();
 		Map<String, String> headers = Collections.singletonMap("Content-Type", imageType.toContentType());
 
@@ -52,7 +53,7 @@ public class GCSFileInfoService extends FileInfoService {
 			Storage.SignUrlOption.withExtHeaders(headers),
 			Storage.SignUrlOption.withV4Signature());
 
-		return new SignedURL(url.toString(), String.join(domain, bucketName, savedFilename));
+		return new SignedURL(url.toString(), String.join("/", domain, bucketName, savedFilename), imageType);
 	}
 
 	@Override

--- a/server/src/main/java/com/codestates/hobby/domain/fileInfo/service/S3FileInfoService.java
+++ b/server/src/main/java/com/codestates/hobby/domain/fileInfo/service/S3FileInfoService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
+import com.codestates.hobby.domain.fileInfo.dto.BasePath;
 import com.codestates.hobby.domain.fileInfo.dto.ImageType;
 import com.codestates.hobby.domain.fileInfo.dto.SignedURL;
 import com.codestates.hobby.domain.fileInfo.entity.FileInfo;
@@ -20,7 +21,7 @@ public class S3FileInfoService extends FileInfoService {
 	}
 
 	@Override
-	public SignedURL generateSignedURL(ImageType type, String basePath) {
+	public SignedURL generateSignedURL(ImageType type, BasePath basePath) {
 		return null;
 	}
 

--- a/server/src/main/java/com/codestates/hobby/domain/fileInfo/support/BasePathConverter.java
+++ b/server/src/main/java/com/codestates/hobby/domain/fileInfo/support/BasePathConverter.java
@@ -1,0 +1,12 @@
+package com.codestates.hobby.domain.fileInfo.support;
+
+import org.springframework.core.convert.converter.Converter;
+
+import com.codestates.hobby.domain.fileInfo.dto.BasePath;
+
+public class BasePathConverter implements Converter<String, BasePath> {
+	@Override
+	public BasePath convert(String str) {
+		return BasePath.valueOf(str.toUpperCase());
+	}
+}

--- a/server/src/main/java/com/codestates/hobby/global/config/MvcConfig.java
+++ b/server/src/main/java/com/codestates/hobby/global/config/MvcConfig.java
@@ -4,10 +4,12 @@ import java.util.List;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import com.codestates.hobby.domain.fileInfo.support.BasePathConverter;
 import com.codestates.hobby.global.config.support.PagingArgumentResolver;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -28,7 +30,11 @@ public class MvcConfig implements WebMvcConfigurer {
 
 	@Override
 	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-		WebMvcConfigurer.super.addArgumentResolvers(resolvers);
 		resolvers.add(new PagingArgumentResolver());
+	}
+
+	@Override
+	public void addFormatters(FormatterRegistry registry) {
+		registry.addConverter(new BasePathConverter());
 	}
 }


### PR DESCRIPTION
## 개요
- [#34 ]

## 작업내용
- 컨트롤러 구현
  - POST `/{base-path}/files` 요청시 signedURL 발급
  - 요청 DTO
    - `Type`: 저장할 수 있는 이미지의 타입 (png, jpeg, webp, gif) 
  - 응답 DTO
    - `SignedURL`: 이미지를 업로드할 수 있는 임시 URL
    - `FileURL`: 이미지를 조회할 수 있는 이미지의 링크
    - `Type`: 업로드할 때 `Content-Type`으로 지정해야되는 타입

## 변경사항
- DTO에 `ContentType`을 반환하도록 `ImageType` 필드 추가
- `BasePath` 및 `ImageType`을 `Enum` 타입으로 변경