### PR TITLE
[BE/Cat] 하이버네이트 L2 Cache 적용 및 테스트

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -25,6 +25,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+
+    // 캐시
+    implementation 'org.hibernate:hibernate-jcache:5.6.14.Final'
+    implementation 'org.ehcache:ehcache:3.9.9'
 
     // 유틸성 라이브러리
     implementation 'org.apache.tomcat.embed:tomcat-embed-jasper'

--- a/server/src/main/java/com/codestates/hobby/domain/category/controller/CategoryController.java
+++ b/server/src/main/java/com/codestates/hobby/domain/category/controller/CategoryController.java
@@ -2,6 +2,8 @@ package com.codestates.hobby.domain.category.controller;
 
 import java.util.List;
 
+import javax.validation.constraints.NotBlank;
+
 import org.springframework.data.domain.PageImpl;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -25,29 +27,26 @@ public class CategoryController {
 	private final CategoryService categoryService;
 	private final CategoryMapper mapper;
 
-	// 카테고리 그룹 목록을 조회한다.
+	@GetMapping
+	public ResponseEntity<?> getAll() {
+		List<Category> categories = categoryService.findAllGroupsWithHobbies();
+		return new ResponseEntity<>(toResponseDto(categories, true), HttpStatus.OK);
+	}
+
 	@GetMapping("/groups")
 	public ResponseEntity<?> getGroups() {
 		List<Category> groups = categoryService.findAllGroups();
-		return new ResponseEntity<>(toResponseDto(groups), HttpStatus.OK);
+		return new ResponseEntity<>(toResponseDto(groups, false), HttpStatus.OK);
 	}
 
-	// 특정 그룹의 카테고리 목록을 조회한다.
 	@GetMapping("/groups/{group}")
-	public ResponseEntity<?> getCategories(@PathVariable String group) {
+	public ResponseEntity<?> getCategories(@PathVariable @NotBlank String group) {
 		List<Category> categories = categoryService.findAllByGroup(group);
-		return new ResponseEntity<>(toResponseDto(categories), HttpStatus.OK);
+		return new ResponseEntity<>(toResponseDto(categories, false), HttpStatus.OK);
 	}
 
-	// 모든 카테고리 목록을 조회한다.
-	@GetMapping
-	public ResponseEntity<?> getAll() {
-		List<Category> categories = categoryService.findAll();
-		return new ResponseEntity<>(toResponseDto(categories), HttpStatus.OK);
-	}
-
-	private MultiResponseDto<?> toResponseDto(List<Category> categories) {
-		List<CategoryDto.Response> responses = mapper.categoriesToResponses(categories);
+	private MultiResponseDto<?> toResponseDto(List<Category> categories, boolean containHobbies) {
+		List<CategoryDto.Response> responses = mapper.categoriesToResponses(categories, containHobbies);
 		return new MultiResponseDto<>(new PageImpl<>(responses));
 	}
 }

--- a/server/src/main/java/com/codestates/hobby/domain/category/entity/Category.java
+++ b/server/src/main/java/com/codestates/hobby/domain/category/entity/Category.java
@@ -1,5 +1,8 @@
 package com.codestates.hobby.domain.category.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.persistence.Cacheable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -9,6 +12,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
@@ -37,7 +41,11 @@ public class Category {
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "group_id")
+	@Cache(usage = CacheConcurrencyStrategy.READ_ONLY, region = CachingConfig.CATEGORY_CACHE)
 	private Category group;
+
+	@OneToMany(mappedBy = "group")
+	private List<Category> categories = new ArrayList<>();
 
 	private Category(String korName, String engName, Category group) {
 		this.korName = korName;
@@ -54,6 +62,6 @@ public class Category {
 	}
 
 	public boolean isGroup() {
-		return group != null;
+		return group == null;
 	}
 }

--- a/server/src/main/java/com/codestates/hobby/domain/category/entity/Category.java
+++ b/server/src/main/java/com/codestates/hobby/domain/category/entity/Category.java
@@ -1,7 +1,6 @@
 package com.codestates.hobby.domain.category.entity;
 
-import java.util.List;
-
+import javax.persistence.Cacheable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -10,11 +9,11 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
 
-import com.codestates.hobby.domain.post.entity.Post;
-import com.codestates.hobby.domain.series.entity.Series;
-import com.codestates.hobby.domain.showcase.entity.Showcase;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+
+import com.codestates.hobby.global.config.CachingConfig;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -23,6 +22,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_ONLY, region = CachingConfig.CATEGORY_CACHE)
 public class Category {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,18 +38,6 @@ public class Category {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "group_id")
 	private Category group;
-
-	@OneToMany(mappedBy = "group")
-	private List<Category> categories;
-
-	@OneToMany(mappedBy = "category")
-	private List<Series> series;
-
-	@OneToMany(mappedBy = "category")
-	private List<Post> posts;
-
-	@OneToMany(mappedBy = "category")
-	private List<Showcase> showcases;
 
 	private Category(String korName, String engName, Category group) {
 		this.korName = korName;

--- a/server/src/main/java/com/codestates/hobby/domain/category/mapper/CategoryMapper.java
+++ b/server/src/main/java/com/codestates/hobby/domain/category/mapper/CategoryMapper.java
@@ -1,6 +1,7 @@
 package com.codestates.hobby.domain.category.mapper;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.mapstruct.Mapper;
 
@@ -9,7 +10,30 @@ import com.codestates.hobby.domain.category.entity.Category;
 
 @Mapper(componentModel = "spring")
 public interface CategoryMapper {
-	CategoryDto.Response categoryToResponse(Category category);
+	default List<CategoryDto.Response> categoriesToResponses(List<Category> categories, boolean containHobbies) {
+		return categories.stream()
+			.map(category -> categoryToResponse(category, containHobbies))
+			.collect(Collectors.toList());
+	}
 
-	List<CategoryDto.Response> categoriesToResponses(List<Category> categories);
+	default CategoryDto.Response categoryToResponse(Category category, boolean containHobbies) {
+		CategoryDto.Response response = new CategoryDto.Response();
+		response.setId(category.getId());
+		response.setKorName(category.getKorName());
+		response.setEngName(category.getEngName());
+
+		return containHobbies && category.isGroup()
+			? categoryToResponse(response, category)
+			: response;
+	}
+
+	default CategoryDto.Response categoryToResponse(CategoryDto.Response response, Category category) {
+		response.setCategories(
+			category.getCategories()
+				.stream()
+				.map(category1 -> categoryToResponse(category1, false))
+				.collect(Collectors.toList())
+		);
+		return response;
+	}
 }

--- a/server/src/main/java/com/codestates/hobby/domain/category/repository/CategoryRepository.java
+++ b/server/src/main/java/com/codestates/hobby/domain/category/repository/CategoryRepository.java
@@ -29,4 +29,8 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
 	@QueryHints(@QueryHint(name = "org.hibernate.cacheable", value = "true"))
 	List<Category> findAllByGroup(Category group);
+
+	@QueryHints(@QueryHint(name = "org.hibernate.cacheable", value = "true"))
+	@Query("select distinct c from Category c join fetch c.categories where c.group is null")
+	List<Category> findAllGroupsWithHobbies();
 }

--- a/server/src/main/java/com/codestates/hobby/domain/category/repository/CategoryRepository.java
+++ b/server/src/main/java/com/codestates/hobby/domain/category/repository/CategoryRepository.java
@@ -3,22 +3,30 @@ package com.codestates.hobby.domain.category.repository;
 import java.util.List;
 import java.util.Optional;
 
+import javax.persistence.QueryHint;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 
 import com.codestates.hobby.domain.category.entity.Category;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+	@QueryHints(@QueryHint(name = "org.hibernate.cacheable", value = "true"))
 	@Query("select c from Category c where c.korName = ?1 or c.engName = ?1")
 	Optional<Category> findByKorNameOrEngName(String name);
 
+	@QueryHints(@QueryHint(name = "org.hibernate.cacheable", value = "true"))
 	@Query("select c from Category c where c.group is null and (c.korName = ?1 or c.engName = ?1)")
 	Optional<Category> findByGroupIsNullAndName(String name);
 
+	@QueryHints(@QueryHint(name = "org.hibernate.cacheable", value = "true"))
 	@Query("select c from Category c where c.group is not null and (c.korName = ?1 or c.engName = ?1)")
 	Optional<Category> findByGroupIsNotNullAndName(String name);
 
+	@QueryHints(@QueryHint(name = "org.hibernate.cacheable", value = "true"))
 	List<Category> findAllByGroupIsNull();
 
+	@QueryHints(@QueryHint(name = "org.hibernate.cacheable", value = "true"))
 	List<Category> findAllByGroup(Category group);
 }

--- a/server/src/main/java/com/codestates/hobby/domain/category/service/CategoryService.java
+++ b/server/src/main/java/com/codestates/hobby/domain/category/service/CategoryService.java
@@ -35,6 +35,10 @@ public class CategoryService {
 		return categoryRepository.findAll();
 	}
 
+	public List<Category> findAllGroupsWithHobbies() {
+		return categoryRepository.findAllGroupsWithHobbies();
+	}
+
 	public List<Category> findAllGroups() {
 		return categoryRepository.findAllByGroupIsNull();
 	}

--- a/server/src/main/java/com/codestates/hobby/domain/category/service/CategoryService.java
+++ b/server/src/main/java/com/codestates/hobby/domain/category/service/CategoryService.java
@@ -22,12 +22,12 @@ public class CategoryService {
 	}
 
 	public Category findHobbyByName(String name) {
-		return categoryRepository.findByGroupIsNotNullAndName(name.toUpperCase())
+		return categoryRepository.findByGroupIsNotNullAndName(name.toLowerCase())
 			.orElseThrow(() -> new IllegalArgumentException("Not found category for " + name));
 	}
 
 	public Category findGroupByName(String name) {
-		return categoryRepository.findByGroupIsNullAndName(name.toUpperCase())
+		return categoryRepository.findByGroupIsNullAndName(name.toLowerCase())
 			.orElseThrow(() -> new IllegalArgumentException("Not found category for " + name));
 	}
 

--- a/server/src/main/java/com/codestates/hobby/global/config/CachingConfig.java
+++ b/server/src/main/java/com/codestates/hobby/global/config/CachingConfig.java
@@ -1,0 +1,40 @@
+package com.codestates.hobby.global.config;
+
+import javax.cache.CacheManager;
+
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.ehcache.config.units.EntryUnit;
+import org.ehcache.config.units.MemoryUnit;
+import org.ehcache.jsr107.Eh107Configuration;
+import org.hibernate.cache.jcache.ConfigSettings;
+import org.springframework.boot.autoconfigure.cache.JCacheManagerCustomizer;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CachingConfig {
+	public static final String CATEGORY_CACHE = "category";
+
+	@Bean
+	public HibernatePropertiesCustomizer hibernatePropertiesCustomizer(CacheManager cacheManager) {
+		return hibernateProperties -> hibernateProperties.put(ConfigSettings.CACHE_MANAGER, cacheManager);
+	}
+
+	@Bean
+	public JCacheManagerCustomizer cacheManagerCustomizer() {
+		return cm -> cm.createCache(CATEGORY_CACHE, getConfiguration());
+	}
+
+	private javax.cache.configuration.Configuration<Object, Object> getConfiguration() {
+		return Eh107Configuration.fromEhcacheCacheConfiguration(
+			CacheConfigurationBuilder.newCacheConfigurationBuilder(
+				Object.class,
+				Object.class,
+				ResourcePoolsBuilder.newResourcePoolsBuilder().heap(1000, EntryUnit.ENTRIES)
+			).withSizeOfMaxObjectSize(1000, MemoryUnit.B));
+	}
+}

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -13,12 +13,21 @@ spring:
     hibernate:
       ddl-auto: create
     properties:
+      javax:
+        cache:
+          provider: org.ehcache.jsr107.EhcacheCachingProvider
+        persistence:
+          sharedCache:
+            mode: ENABLE_SELECTIVE
       hibernate:
         format_sql: true
-  servlet:
-    multipart:
-      max-file-size: 5MB      # 파일당 최대크기
-      max-request-size: 50MB  # 요청당 최대크기
+        generate_statistics: true
+        cache:
+          use_query_cache: true
+          use_second_level_cache: true
+          region:
+            factory_class: org.hibernate.cache.jcache.JCacheRegionFactory
+    defer-datasource-initialization: true
   output:
     ansi:
       enabled: always
@@ -33,9 +42,9 @@ cloud:
 logging:
   level:
     org:
-      springframework:
-        orm:
-          jpa: DEBUG
+      hibernate:
+        type: trace
+
 server:
   port: 8080
   servlet:

--- a/server/src/main/resources/data.sql
+++ b/server/src/main/resources/data.sql
@@ -1,0 +1,27 @@
+INSERT INTO CATEGORY(id, group_id, kor_name, eng_name)
+VALUES (default, null, '스포츠', 'sports'),
+       (default, null, '금융', 'finance'),
+       (default, null, '게임', 'game'),
+       (default, null, '사교', 'social'),
+       (default, null, '예술/문화', 'art/culture'),
+       (default, null, '창작/제작', 'creation/making');
+
+INSERT INTO CATEGORY(id, group_id, kor_name, eng_name)
+VALUES (default, 1, '야구', 'baseball'),
+       (default, 1, '축구', 'soccer'),
+       (default, 1, '농구', 'basketball'),
+       (default, 2, '주식', 'stocks'),
+       (default, 2, '부동산', 'real estate'),
+       (default, 2, '가상화폐', 'virtual currency'),
+       (default, 3, '롤', 'league of legends'),
+       (default, 3, '스타', 'starcraft'),
+       (default, 3, '보드게임', 'board game'),
+       (default, 4, '음주', 'drinking'),
+       (default, 4, '파티', 'party'),
+       (default, 4, '여행', 'travel'),
+       (default, 5, '영화', 'movie'),
+       (default, 5, '음악', 'music'),
+       (default, 5, '책', 'book'),
+       (default, 6, '공예', 'craft'),
+       (default, 6, '뜨개질', 'knitting'),
+       (default, 6, '드로잉', 'drawing');

--- a/server/src/test/java/com/codestates/hobby/domain/category/controller/CategoryControllerTest.java
+++ b/server/src/test/java/com/codestates/hobby/domain/category/controller/CategoryControllerTest.java
@@ -3,7 +3,6 @@ package com.codestates.hobby.domain.category.controller;
 import static com.codestates.hobby.domain.stub.CategoryStub.*;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.util.List;
@@ -30,7 +29,8 @@ class CategoryControllerTest extends ControllerTest {
 	List<CategoryDto.Response> response;
 
 	@BeforeAll
-	void beforeAll() {
+	protected void beforeAll() {
+		super.beforeAll();
 		response = List.of(groupResponse());
 	}
 
@@ -38,7 +38,9 @@ class CategoryControllerTest extends ControllerTest {
 	void getGroups() throws Exception {
 		CategoryDto.Response response = groupResponse();
 		response.setCategories(null);
-		givens(List.of(response));
+
+		given(service.findAllGroups()).willReturn(List.of());
+		given(mapper.categoriesToResponses(anyList(), anyBoolean())).willReturn(List.of(response));
 
 		mvc
 			.perform(get("/categories/groups"))
@@ -48,26 +50,22 @@ class CategoryControllerTest extends ControllerTest {
 
 	@Test
 	void getCategories() throws Exception {
-		givens(response.get(0).getCategories());
+		given(service.findAllGroups()).willReturn(List.of());
+		given(mapper.categoriesToResponses(anyList(), anyBoolean())).willReturn(response.get(0).getCategories());
 
 		mvc
 			.perform(get("/categories/groups/exercise"))
-			.andDo(print())
 			.andExpect(jsonPath("$.data..categories").doesNotExist());
 	}
 
 	@Test
 	void getAll() throws Exception {
-		givens(response);
+		given(service.findAllGroups()).willReturn(List.of());
+		given(mapper.categoriesToResponses(anyList(), anyBoolean())).willReturn(response);
 
 		mvc
 			.perform(get("/categories"))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data..categories").exists());
-	}
-
-	private void givens(List<CategoryDto.Response> categories) {
-		given(service.findAllGroups()).willReturn(List.of());
-		given(mapper.categoriesToResponses(anyList())).willReturn(categories);
 	}
 }

--- a/server/src/test/java/com/codestates/hobby/domain/category/controller/CategoryIntegrationTest.java
+++ b/server/src/test/java/com/codestates/hobby/domain/category/controller/CategoryIntegrationTest.java
@@ -1,0 +1,44 @@
+package com.codestates.hobby.domain.category.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class CategoryIntegrationTest {
+	@Autowired
+	MockMvc mvc;
+
+	@Test
+	void getAll() throws Exception {
+		mvc
+			.perform(get("/categories"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data..categories").exists())
+			.andExpect(jsonPath("$.data.length()").value(6))
+			.andExpect(jsonPath("sum($.data..categories.length())").value(18));
+	}
+
+	@Test
+	void getGroups() throws Exception {
+		mvc
+			.perform(get("/categories/groups"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data..categories").doesNotExist())
+			.andExpect(jsonPath("$.data.length()").value(6));
+	}
+
+	@Test
+	void getCategories() throws Exception {
+		mvc
+			.perform(get("/categories/groups/sports"))
+			.andExpect(jsonPath("$.data..categories").doesNotExist())
+			.andExpect(jsonPath("$.data.length()").value(3));
+	}
+}

--- a/server/src/test/java/com/codestates/hobby/domain/category/repository/CategoryRepositoryTest.java
+++ b/server/src/test/java/com/codestates/hobby/domain/category/repository/CategoryRepositoryTest.java
@@ -1,0 +1,129 @@
+package com.codestates.hobby.domain.category.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.CacheRegionStatistics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.codestates.hobby.domain.category.entity.Category;
+
+@DataJpaTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CategoryRepositoryTest {
+	@Autowired
+	CategoryRepository repository;
+
+	@Autowired
+	SessionFactory sf;
+
+	@Autowired
+	TestEntityManager em;
+
+	CacheRegionStatistics query, entity;
+
+	@BeforeEach
+	void beforeEach() {
+		sf.getStatistics().clear();
+		sf.getCache().evictAllRegions();
+		query = sf.getStatistics().getCacheRegionStatistics("default-query-results-region");
+		entity = sf.getStatistics().getCacheRegionStatistics("category");
+	}
+
+	@Test
+	@Transactional(readOnly = true)
+	void findById() {
+		repository.findById(1L);
+		assertEquals(1, entity.getPutCount());
+
+		em.clear();
+
+		repository.findById(1L);
+		assertEquals(1, entity.getHitCount());
+	}
+
+	@Test
+	@Transactional(readOnly = true)
+	void findByKorNameOrEngName() {
+		repository.findAllByGroupIsNull();
+		assertEquals(1, query.getPutCount());
+		assertEquals(6, entity.getPutCount());
+
+		em.clear();
+
+		repository.findAllByGroupIsNull();
+		assertEquals(1, query.getHitCount());
+		assertEquals(6, entity.getHitCount());
+	}
+
+	@Test
+	@Transactional(readOnly = true)
+	void findByGroupIsNullAndName() {
+		Category cat = repository.findByGroupIsNullAndName("sports").get();
+		assertEquals(1, entity.getPutCount());
+
+		em.clear();
+		repository.findById(cat.getId());
+		assertEquals(1, entity.getHitCount());
+
+		em.clear();
+		repository.findByGroupIsNullAndName("sports");
+		assertEquals(2, entity.getHitCount());
+	}
+
+	@Test
+	@Transactional(readOnly = true)
+	void findByGroupIsNotNullAndName() {
+		repository.findByGroupIsNotNullAndName("soccer");
+		assertEquals(1, query.getPutCount());
+		assertEquals(1, entity.getPutCount());
+
+		em.clear();
+
+		repository.findByGroupIsNotNullAndName("soccer");
+		assertEquals(1, entity.getHitCount());
+	}
+
+	@Test
+	@Transactional(readOnly = true)
+	void findAllByGroupIsNull() {
+		repository.findAllByGroupIsNull();
+		assertEquals(1, query.getPutCount());
+		assertEquals(6, entity.getPutCount());
+
+		em.clear();
+
+		repository.findAllByGroupIsNull();
+		assertEquals(1, query.getHitCount());
+		assertEquals(6, entity.getHitCount());
+	}
+
+	@Test
+	@Transactional(readOnly = true)
+	void findAllByGroup() {
+		Category group = repository.findByKorNameOrEngName("sports").get();
+
+		em.clear();
+		repository.findAllByGroup(group);
+		assertEquals(2, query.getPutCount());
+		assertEquals(4, entity.getPutCount());
+
+		em.clear();
+		repository.findAllByGroup(group);
+		assertEquals(1, query.getHitCount());
+		assertEquals(3, entity.getHitCount());
+	}
+
+	@Test
+	@Transactional(readOnly = true)
+	void findAll() {
+		int size = repository.findAll().size();
+		assertEquals(size, entity.getPutCount());
+	}
+}

--- a/server/src/test/java/com/codestates/hobby/domain/category/service/CategoryServiceTest.java
+++ b/server/src/test/java/com/codestates/hobby/domain/category/service/CategoryServiceTest.java
@@ -1,103 +1,90 @@
 package com.codestates.hobby.domain.category.service;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
 
 import java.util.List;
+import java.util.Optional;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.codestates.hobby.domain.category.entity.Category;
 import com.codestates.hobby.domain.category.repository.CategoryRepository;
+import com.codestates.hobby.domain.stub.CategoryStub;
 
-@SpringBootTest
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(MockitoExtension.class)
 class CategoryServiceTest {
-	@Autowired
-	CategoryRepository repository;
-
-	@Autowired
+	@InjectMocks
 	CategoryService service;
 
-	@BeforeAll
-	void beforeAll() {
-		deleteAll();
-		setUp();
-	}
-
-	@AfterAll
-	void afterAll() {
-		deleteAll();
-	}
-
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
-	void setUp() {
-		Category group1 = repository.save(Category.createParent("그룹1", "group1"));
-		Category group2 = repository.save(Category.createParent("그룹2", "group2"));
-
-		repository.saveAll(List.of(
-			Category.createChild("취미1", "hobby1", group1),
-			Category.createChild("취미2", "hobby2", group1),
-			Category.createChild("취미3", "hobby3", group1),
-			Category.createChild("취미4", "hobby4", group2),
-			Category.createChild("취미5", "hobby5", group2),
-			Category.createChild("취미6", "hobby6", group2)));
-	}
-
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
-	void deleteAll() {
-		repository.deleteAll();
-	}
+	@Mock
+	CategoryRepository repository;
 
 	@Test
 	void 아이디로_조회한다() {
+		given(repository.findById(anyLong())).willReturn(Optional.of(CategoryStub.group()));
+
 		assertDoesNotThrow(() -> service.findById(1L));
 	}
 
 	@Test
 	void 이름으로_조회한다() {
-		Category cat = assertDoesNotThrow(() -> service.findHobbyByName("취미1"));
-		Category group = assertDoesNotThrow(() -> service.findGroupByName("그룹1"));
+		given(repository.findByGroupIsNullAndName(anyString())).willReturn(Optional.of(CategoryStub.group()));
+		given(repository.findByGroupIsNotNullAndName(anyString())).willReturn(Optional.of(CategoryStub.hobby()));
 
-		assertNotNull(cat.getGroup());
-		assertNull(group.getGroup());
-		assertEquals(group.getId(), cat.getGroup().getId());
+		Category group = assertDoesNotThrow(() -> service.findGroupByName("그룹1"));
+		Category hobby = assertDoesNotThrow(() -> service.findHobbyByName("취미1"));
+
+		assertTrue(group.isGroup());
+		assertFalse(hobby.isGroup());
 	}
 
 	@Test
 	void 취미로_그룹을_조회하면_실패한다() {
+		given(repository.findByGroupIsNullAndName(anyString())).willThrow(new IllegalArgumentException());
+
 		assertThrows(IllegalArgumentException.class, () -> service.findGroupByName("HOBBY1"));
 	}
 
 	@Test
 	void 그룹으로_취미를_조회하면_실패한다() {
+		given(repository.findByGroupIsNotNullAndName(anyString())).willThrow(new IllegalArgumentException());
+
 		assertThrows(IllegalArgumentException.class, () -> service.findHobbyByName("그룹1"));
 	}
 
 	@Test
 	void 전체를_조회한다() {
-		assertEquals(service.findAll().size(), 8);
-		assertEquals(service.findAllGroups().size(), 2);
+		given(repository.findAll()).willReturn(List.of(CategoryStub.group()));
+
+		assertEquals(service.findAll().size(), 1);
 	}
 
 	@Test
 	void 그룹목록을_조회한다() {
-		assertEquals(service.findAllGroups().size(), 2);
+		given(repository.findAllByGroupIsNull()).willReturn(List.of(CategoryStub.group()));
+		given(repository.findAllGroupsWithHobbies()).willReturn(List.of(CategoryStub.group()));
+
+		assertEquals(service.findAllGroups().size(), 1);
+		assertEquals(service.findAllGroupsWithHobbies().size(), 1);
 	}
 
 	@Test
 	void 그룹명으로_취미목록을_조회한다() {
-		assertEquals(service.findAllByGroup("group1").size(), 3);
+		given(repository.findAllByGroup(any())).willReturn(List.of(CategoryStub.hobby(), CategoryStub.hobby()));
+		given(repository.findByGroupIsNullAndName(anyString())).willReturn(Optional.of(CategoryStub.group()));
+
+		assertEquals(service.findAllByGroup("group").size(), 2);
 	}
 
 	@Test
 	void 취미로_취미목록을_조회하면_실패한다() {
-		assertThrows(IllegalArgumentException.class, () -> service.findAllByGroup("HOBBY1"));
+		given(repository.findByGroupIsNullAndName(anyString())).willThrow(new IllegalArgumentException());
+
+		assertThrows(IllegalArgumentException.class, () -> service.findAllByGroup("HOBBY"));
 	}
 }

--- a/server/src/test/java/com/codestates/hobby/domain/stub/CategoryStub.java
+++ b/server/src/test/java/com/codestates/hobby/domain/stub/CategoryStub.java
@@ -3,6 +3,7 @@ package com.codestates.hobby.domain.stub;
 import java.util.List;
 
 import com.codestates.hobby.domain.category.dto.CategoryDto;
+import com.codestates.hobby.domain.category.entity.Category;
 
 public class CategoryStub {
 	public static CategoryDto.Response groupResponse() {
@@ -23,5 +24,13 @@ public class CategoryStub {
 		cat2.setEngName("SWIMMING");
 
 		return group;
+	}
+
+	public static Category group() {
+		return Category.createParent("운동", "sports");
+	}
+
+	public static Category hobby() {
+		return Category.createChild("축구", "soccer", group());
 	}
 }

--- a/server/src/test/java/com/codestates/hobby/utils/ControllerTest.java
+++ b/server/src/test/java/com/codestates/hobby/utils/ControllerTest.java
@@ -33,7 +33,7 @@ public abstract class ControllerTest {
 	protected MockMvc mvc;
 
 	@BeforeAll
-	void beforeAll() {
+	protected void beforeAll() {
 		mvc = MockMvcBuilders.webAppContextSetup(ctx).build();
 	}
 


### PR DESCRIPTION
## 작업사항
- 하이버네이트 L2 Cache 적용 (엔티티 및 쿼리)
- Category Entity 양방향 매핑으로 변경
- 통합테스트 및 Repository Layer 테스트 실행
- 카테고리 스텁데이터 구현

## 변경사항
- `ServiceTest`: 단위테스트로 변경
- `ControllerTest`: `BeforeAll` 접근제어자 protect로 변경

## 기타
- 이건 하이버네이트 2차 캐시 적용한겁니다
- `category` 브랜치는 스프링 캐시 적용한건데 둘 중 어떤게 더 나을까요? 
- 하이버네이트 
  - (장) 엔티티 조인시 카테고리가 캐싱됐다면 그 카테고리를 불러올 수 있다.
  - (단) 2차 캐시가 활성화돼서 다른 엔티티도 먼저 2차 캐시에 접근한다.
- 스프링 캐시
  - (장) 구현이 간편하다.
  - (단) 엔티티 조인시 캐싱된 카테고리를 가져올 수 없다.