### PR TITLE
[BE/Post] Controller, Dto, Mapper 리펙토링 

### DIFF
--- a/server/src/main/java/com/codestates/hobby/domain/post/controller/PostCommendController.java
+++ b/server/src/main/java/com/codestates/hobby/domain/post/controller/PostCommendController.java
@@ -21,7 +21,7 @@ public class PostCommendController {
                                   @AuthenticationPrincipal Long memberId) {
         postDto.setMemberId(memberId);
         Post post = postService.post(postDto);
-        return new ResponseEntity<>(post, HttpStatus.CREATED);
+        return new ResponseEntity<>(post.getId(), HttpStatus.CREATED);
     }
 
     @PatchMapping("/{post-id}")
@@ -30,7 +30,7 @@ public class PostCommendController {
                                    @AuthenticationPrincipal Long memberId) {
         patchDto.setProperties(memberId, postId);
         Post post = postService.update(patchDto);
-        return new ResponseEntity<>(post,HttpStatus.OK);
+        return new ResponseEntity<>(post.getId(),HttpStatus.OK);
     }
 
     @DeleteMapping("/{post-id}")

--- a/server/src/main/java/com/codestates/hobby/domain/post/controller/PostCommentController.java
+++ b/server/src/main/java/com/codestates/hobby/domain/post/controller/PostCommentController.java
@@ -24,8 +24,8 @@ public class PostCommentController {
                                   @RequestBody PostCommentDto.Post postDto,
                                   @AuthenticationPrincipal Long memberId) {
         postDto.setProperties(postId, memberId);
-        PostComment postComment = postCommentService.post(postDto);
-        return new ResponseEntity<>(postComment, HttpStatus.CREATED);
+        postCommentService.post(postDto);
+        return new ResponseEntity<>(HttpStatus.CREATED);
     }
 
     @PatchMapping("/{comment-id}")
@@ -36,8 +36,8 @@ public class PostCommentController {
             @AuthenticationPrincipal Long memberId
     ) {
         patchDto.setProperties(memberId, postId, commentId);
-        PostComment postComment = postCommentService.update(patchDto);
-        return new ResponseEntity<>(postComment,HttpStatus.OK);
+        postCommentService.update(patchDto);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 
     @DeleteMapping("/{comment-id}")

--- a/server/src/main/java/com/codestates/hobby/domain/post/controller/PostQueryController.java
+++ b/server/src/main/java/com/codestates/hobby/domain/post/controller/PostQueryController.java
@@ -13,6 +13,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping
@@ -23,8 +26,13 @@ public class PostQueryController {
     @GetMapping("/posts/{post-id}")
     public ResponseEntity<?> get(@PathVariable("post-id") long postId, @AuthenticationPrincipal Long memberId) {
         Post post = postService.findById(postId);
-
         PostDto.Response response = mapper.postToResponse(post);
+        mapper.setProperties(response,memberId);
+        mapper.setSeries(response, response.getSeriesId());
+        if (response.getSeriesId() != null){
+            List<String> seriesPostUrl = post.getSeries().getPosts().stream().map(seriesPost -> "http://localhost:8080/posts/"+seriesPost.getId()).collect(Collectors.toList());
+            response.setSeriesPosts(seriesPostUrl);
+        }
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 

--- a/server/src/main/java/com/codestates/hobby/domain/post/dto/PostDto.java
+++ b/server/src/main/java/com/codestates/hobby/domain/post/dto/PostDto.java
@@ -3,7 +3,6 @@ package com.codestates.hobby.domain.post.dto;
 import com.codestates.hobby.domain.member.dto.MemberDto;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.*;
-import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
@@ -60,10 +59,9 @@ public class PostDto {
         private String category;
         private Long seriesId;
         private boolean isItWriter;
-        private List<String> imgUrls;
         private List<PostCommentDto.Response> comments;
         private MemberDto.SimpleResponse writer;
-        private List<SimpleResponse> categoryPosts;
+        private List<String> seriesPosts;
         private LocalDateTime createdDate;
         private LocalDateTime modifiedDate;
     }

--- a/server/src/main/java/com/codestates/hobby/domain/post/mapper/PostMapper.java
+++ b/server/src/main/java/com/codestates/hobby/domain/post/mapper/PostMapper.java
@@ -12,11 +12,15 @@ import java.util.Optional;
 @Mapper(componentModel = "spring", uses = {MemberMapper.class, PostCommentMapper.class})
 public interface PostMapper {
     @Mapping(target = "writer", source = "member")
+    @Mapping(target = "comments", expression = "java(post.getComments().size())")
+    @Mapping(target = "seriesPosts", ignore = true)
+    @Mapping(target = "seriesId", ignore = true)
     PostDto.Response postToResponse(Post post);
 
     @Mapping(target = "writer", source = "member")
     @Mapping(target = "comments", expression = "java(post.getComments().size())")
     @Mapping(target = "thumbnailUrl", expression = "java(post.getImages().get(0).getFileURL())")
+    @Mapping(target = "seriesId", ignore = true)
     PostDto.SimpleResponse postToSimpleResponse(Post post);
 
     default String toString(Category value){
@@ -35,5 +39,9 @@ public interface PostMapper {
     default void setProperties(PostDto.SimpleResponse response, Long memberId) {
         Optional.ofNullable(memberId)
                 .ifPresent(id -> response.setItWriter(id.equals(response.getWriter().getId())));
+    }
+
+    default void setSeries(PostDto.Response response, Long seriesId){
+        Optional.ofNullable(seriesId).ifPresent(id -> response.setSeriesId(seriesId));
     }
 }


### PR DESCRIPTION
## 개요
- Post매핑 시 SeriesPosts의 url 제공
- Controller return값 일치를 위한 수정
- Series가 존재하지 않는 Post를 위한 리팩토링

## 변경사항
- PostDto의 Series와 SeriesPosts값 수동 매핑