### PR TITLE
[BE] Service 계층 3차 구현

### DIFF
--- a/server/src/main/java/com/codestates/hobby/domain/category/service/CategoryService.java
+++ b/server/src/main/java/com/codestates/hobby/domain/category/service/CategoryService.java
@@ -2,6 +2,8 @@ package com.codestates.hobby.domain.category.service;
 
 import java.util.List;
 
+import com.codestates.hobby.global.exception.BusinessLogicException;
+import com.codestates.hobby.global.exception.ExceptionCode;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,17 +20,17 @@ public class CategoryService {
 
 	public Category findById(long categoryId) {
 		return categoryRepository.findById(categoryId)
-			.orElseThrow(() -> new IllegalArgumentException("Not found category for " + categoryId));
+			.orElseThrow(() -> new BusinessLogicException(ExceptionCode.CATEGORY_NOT_FOUND));
 	}
 
 	public Category findHobbyByName(String name) {
 		return categoryRepository.findByGroupIsNotNullAndName(name.toLowerCase())
-			.orElseThrow(() -> new IllegalArgumentException("Not found category for " + name));
+			.orElseThrow(() -> new BusinessLogicException(ExceptionCode.CATEGORY_NOT_FOUND));
 	}
 
 	public Category findGroupByName(String name) {
 		return categoryRepository.findByGroupIsNullAndName(name.toLowerCase())
-			.orElseThrow(() -> new IllegalArgumentException("Not found category for " + name));
+			.orElseThrow(() -> new BusinessLogicException(ExceptionCode.CATEGORY_NOT_FOUND));
 	}
 
 	public List<Category> findAll() {

--- a/server/src/main/java/com/codestates/hobby/domain/member/service/MemberService.java
+++ b/server/src/main/java/com/codestates/hobby/domain/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.codestates.hobby.domain.member.service;
 
-import com.codestates.hobby.domain.fileInfo.service.FileInfoService;
+import com.codestates.hobby.global.exception.BusinessLogicException;
+import com.codestates.hobby.global.exception.ExceptionCode;
 import com.codestates.hobby.domain.member.dto.MemberDto;
 import com.codestates.hobby.domain.member.repository.MemberRepository;
 import com.codestates.hobby.domain.member.entity.Member;
@@ -58,30 +59,30 @@ public class MemberService {
     @Transactional(readOnly = true)
     private void verifyExistEmail(String email) {
         Optional<Member> member = repository.findByEmail(email);
-        if(member.isPresent()) throw new RuntimeException("Email Exists");
+        if(member.isPresent()) throw new BusinessLogicException(ExceptionCode.EXISTS_EMAIL);
     }
 
     @Transactional(readOnly = true)
     private void verifyExistNickname(String nickname) {
         Optional<Member> member = repository.findByNickname(nickname);
-        if(member.isPresent()) throw new RuntimeException("Nickname Exists");
+        if(member.isPresent()) throw new BusinessLogicException(ExceptionCode.EXISTS_NICKNAME);
     }
 
     @Transactional(readOnly = true)
     public Member findMemberById(long memberId) {
         Optional<Member> optionalMember = repository.findById(memberId);
-        Member findMember = optionalMember.orElseThrow(() -> new RuntimeException("Not Found Member"));
+        Member findMember = optionalMember.orElseThrow(() -> new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND));
         if(findMember.getMemberStatus().equals(Member.MemberStatus.MEMBER_QUIT))
-            throw new RuntimeException("탈퇴한 멤버입니다.");
+            throw new BusinessLogicException(ExceptionCode.WITHDRAWAL_MEMBER);
         return findMember;
     }
 
     @Transactional(readOnly = true)
     public Member findMemberByEmail(String email) {
         Optional<Member> optionalMember = repository.findByEmail(email);
-        Member findMember = optionalMember.orElseThrow(() -> new RuntimeException("Not Found Member"));
+        Member findMember = optionalMember.orElseThrow(() -> new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND));
         if(findMember.getMemberStatus().equals(Member.MemberStatus.MEMBER_QUIT))
-            throw new RuntimeException("탈퇴한 멤버입니다.");
+            throw new BusinessLogicException(ExceptionCode.WITHDRAWAL_MEMBER);
         return findMember;
     }
 }

--- a/server/src/main/java/com/codestates/hobby/domain/post/controller/PostQueryController.java
+++ b/server/src/main/java/com/codestates/hobby/domain/post/controller/PostQueryController.java
@@ -29,10 +29,7 @@ public class PostQueryController {
         PostDto.Response response = mapper.postToResponse(post);
         mapper.setProperties(response,memberId);
         mapper.setSeries(response, response.getSeriesId());
-        if (response.getSeriesId() != null){
-            List<String> seriesPostUrl = post.getSeries().getPosts().stream().map(seriesPost -> "http://localhost:8080/posts/"+seriesPost.getId()).collect(Collectors.toList());
-            response.setSeriesPosts(seriesPostUrl);
-        }
+        mapper.setSeriesPostUrl(response,post);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 

--- a/server/src/main/java/com/codestates/hobby/domain/post/mapper/PostMapper.java
+++ b/server/src/main/java/com/codestates/hobby/domain/post/mapper/PostMapper.java
@@ -7,12 +7,15 @@ import com.codestates.hobby.domain.post.entity.Post;
 import com.codestates.hobby.domain.series.entity.Series;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Mapper(componentModel = "spring", uses = {MemberMapper.class, PostCommentMapper.class})
 public interface PostMapper {
     @Mapping(target = "writer", source = "member")
-    @Mapping(target = "comments", expression = "java(post.getComments().size())")
     @Mapping(target = "seriesPosts", ignore = true)
     @Mapping(target = "seriesId", ignore = true)
     PostDto.Response postToResponse(Post post);
@@ -43,5 +46,12 @@ public interface PostMapper {
 
     default void setSeries(PostDto.Response response, Long seriesId){
         Optional.ofNullable(seriesId).ifPresent(id -> response.setSeriesId(seriesId));
+    }
+    default void setSeriesPostUrl(PostDto.Response response, Post post){
+        if (response.getSeriesId() != null){
+            List<String> seriesPostUrl = post.getSeries().getPosts().stream().map(seriesPost ->
+                    "http://localhost:8080/posts/"+seriesPost.getId()).collect(Collectors.toList());
+            response.setSeriesPosts(seriesPostUrl);
+        }
     }
 }

--- a/server/src/main/java/com/codestates/hobby/domain/post/service/PostCommentService.java
+++ b/server/src/main/java/com/codestates/hobby/domain/post/service/PostCommentService.java
@@ -1,5 +1,7 @@
 package com.codestates.hobby.domain.post.service;
 
+import com.codestates.hobby.global.exception.BusinessLogicException;
+import com.codestates.hobby.global.exception.ExceptionCode;
 import com.codestates.hobby.domain.member.entity.Member;
 import com.codestates.hobby.domain.member.service.MemberService;
 import com.codestates.hobby.domain.post.dto.PostCommentDto;
@@ -32,16 +34,16 @@ public class PostCommentService {
     @Transactional
     public PostComment update(PostCommentDto.Patch patchDto) {
         PostComment findComment = findVerifiedComment(patchDto.getCommentId());
-        if (!isMatchMember(findComment, patchDto.getMemberId()))  throw new RuntimeException("권한이 없습니다.");
-        else findComment.update(patchDto.getContent());
+        isMatchMember(findComment, patchDto.getMemberId());
+        findComment.update(patchDto.getContent());
         return postCommentRepository.save(findComment);
     }
 
     @Transactional
     public void delete(long memberId, long postId, long commentId) {
         PostComment findComment = findVerifiedComment(commentId);
-        if (!isMatchMember(findComment, memberId))  throw new RuntimeException("권한이 없습니다.");
-        if (postService.findVerifiedPost(postId) == null) throw new RuntimeException("포스트가 존재하지 않습니다.");
+        isMatchMember(findComment,memberId);
+        postService.findVerifiedPost(postId);
         postCommentRepository.delete(findComment);
 
     }
@@ -62,12 +64,13 @@ public class PostCommentService {
     }
 
     public boolean isMatchMember(PostComment postComment, long memberId){
+        boolean isMatch = postComment.getMember().getId().equals(memberId);
+        if (!isMatch) throw new BusinessLogicException(ExceptionCode.NOT_MATCH_MEMBER);
         return postComment.getMember().getId().equals(memberId);
     }
-
     private PostComment findVerifiedComment(long commentId) {
         Optional<PostComment> optionalComment = postCommentRepository.findById(commentId);
-        PostComment findPostComment = optionalComment.orElseThrow(() -> new RuntimeException("data is null"));
+        PostComment findPostComment = optionalComment.orElseThrow(() -> new BusinessLogicException(ExceptionCode.COMMENT_NOT_FOUND));
         return findPostComment;
     }
 }

--- a/server/src/main/java/com/codestates/hobby/domain/post/service/PostService.java
+++ b/server/src/main/java/com/codestates/hobby/domain/post/service/PostService.java
@@ -1,5 +1,7 @@
 package com.codestates.hobby.domain.post.service;
 
+import com.codestates.hobby.global.exception.BusinessLogicException;
+import com.codestates.hobby.global.exception.ExceptionCode;
 import com.codestates.hobby.domain.post.repository.PostRepository;
 import com.codestates.hobby.domain.category.entity.Category;
 import com.codestates.hobby.domain.category.service.CategoryService;
@@ -44,32 +46,30 @@ public class PostService {
     @Transactional
     public Post update(PostDto.Patch patchDto){
         Post findPost = findVerifiedPost(patchDto.getPostId());
-        if (!isMatchMember(findPost, memberService.findMemberById(patchDto.getMemberId()).getId())) throw new RuntimeException("권한이 없습니다.");
-        else {
-            if (patchDto.getSeriesId() != null) {
-                if (patchDto.getImgUrls() != null) findPost.updatePost(patchDto.getTitle(), patchDto.getContent(),
-                        categoryService.findHobbyByName(patchDto.getCategory()), seriesService.findById(patchDto.getSeriesId()), patchDto.getImgUrls());
-                else findPost.updatePost(patchDto.getTitle(), patchDto.getContent(), categoryService.findHobbyByName(patchDto.getCategory()),
-                        seriesService.findById(patchDto.getSeriesId()));
-            } else {
-                if (patchDto.getImgUrls() != null) findPost.updatePost(patchDto.getTitle(), patchDto.getContent()
-                        , categoryService.findHobbyByName(patchDto.getCategory()), patchDto.getImgUrls());
-                else findPost.updatePost(patchDto.getTitle(), patchDto.getContent()
-                        , categoryService.findHobbyByName(patchDto.getCategory()));
-            }
-            return postRepository.save(findPost);
+        isMatchMember(findPost, patchDto.getMemberId());
+        if (patchDto.getSeriesId() != null) {
+            if (patchDto.getImgUrls() != null) findPost.updatePost(patchDto.getTitle(), patchDto.getContent(),
+                    categoryService.findHobbyByName(patchDto.getCategory()), seriesService.findById(patchDto.getSeriesId()), patchDto.getImgUrls());
+            else findPost.updatePost(patchDto.getTitle(), patchDto.getContent(), categoryService.findHobbyByName(patchDto.getCategory()),
+                    seriesService.findById(patchDto.getSeriesId()));
+        } else {
+            if (patchDto.getImgUrls() != null) findPost.updatePost(patchDto.getTitle(), patchDto.getContent()
+                    , categoryService.findHobbyByName(patchDto.getCategory()), patchDto.getImgUrls());
+            else findPost.updatePost(patchDto.getTitle(), patchDto.getContent()
+                    , categoryService.findHobbyByName(patchDto.getCategory()));
         }
+        return postRepository.save(findPost);
     }
     @Transactional
     public void delete(long postId, long memberId){
         Post findPost = findVerifiedPost(postId);
-        if (!isMatchMember(findPost, memberService.findMemberById(memberId).getId())) throw new RuntimeException("권한이 없습니다.");
-        else postRepository.delete(findPost);
+        isMatchMember(findPost,memberId);
+        postRepository.delete(findPost);
     }
 
     @Transactional
     public Post findById(long postId) {
-        return postRepository.findById(postId).orElseThrow(() -> new RuntimeException("Cannot find post"));
+        return findVerifiedPost(postId);
     }
 
     @Transactional(readOnly = true)
@@ -99,11 +99,13 @@ public class PostService {
 
     public Post findVerifiedPost(long postId){
         Optional<Post> optionalPost = postRepository.findById(postId);
-        Post findPost = optionalPost.orElseThrow(() -> new RuntimeException("data is null"));
+        Post findPost = optionalPost.orElseThrow(() ->new BusinessLogicException(ExceptionCode.POST_NOT_FOUND));
         return findPost;
     }
 
     public boolean isMatchMember(Post post, long memberId){
+        boolean isMatch = post.getMember().getId().equals(memberId);
+        if (!isMatch) throw new BusinessLogicException(ExceptionCode.NOT_MATCH_MEMBER);
         return post.getMember().getId().equals(memberId);
     }
 

--- a/server/src/main/java/com/codestates/hobby/domain/series/service/SeriesService.java
+++ b/server/src/main/java/com/codestates/hobby/domain/series/service/SeriesService.java
@@ -2,6 +2,8 @@ package com.codestates.hobby.domain.series.service;
 
 import com.codestates.hobby.domain.category.entity.Category;
 import com.codestates.hobby.domain.category.service.CategoryService;
+import com.codestates.hobby.global.exception.BusinessLogicException;
+import com.codestates.hobby.global.exception.ExceptionCode;
 import com.codestates.hobby.domain.member.entity.Member;
 import com.codestates.hobby.domain.member.service.MemberService;
 import com.codestates.hobby.domain.series.dto.SeriesDto;
@@ -41,13 +43,13 @@ public class SeriesService {
 
     @Transactional
     public void delete(long seriesId, long memberId) {
-        seriesRepository.findByIdAndMemberId(seriesId, memberId).orElseThrow(() -> new RuntimeException("not found series"));
+        seriesRepository.findByIdAndMemberId(seriesId, memberId).orElseThrow(() -> new BusinessLogicException(ExceptionCode.SERIES_NOT_FOUND));
         seriesRepository.deleteById(seriesId);
     }
 
     @Transactional(readOnly = true)
     public Series findById(long seriesId) {
-        return seriesRepository.findById(seriesId).orElseThrow(()->new RuntimeException("not found series"));
+        return seriesRepository.findById(seriesId).orElseThrow(()->new BusinessLogicException(ExceptionCode.SERIES_NOT_FOUND));
     }
 
 
@@ -71,6 +73,6 @@ public class SeriesService {
 
     @Transactional(readOnly = true)
     public Series findById(Long seriesId) {
-        return seriesRepository.findById(seriesId).orElseThrow(() -> new RuntimeException("not found series"));
+        return seriesRepository.findById(seriesId).orElseThrow(() -> new BusinessLogicException(ExceptionCode.SERIES_NOT_FOUND));
     }
 }

--- a/server/src/main/java/com/codestates/hobby/domain/showcase/service/ShowcaseCommentService.java
+++ b/server/src/main/java/com/codestates/hobby/domain/showcase/service/ShowcaseCommentService.java
@@ -1,5 +1,7 @@
 package com.codestates.hobby.domain.showcase.service;
 
+import com.codestates.hobby.global.exception.BusinessLogicException;
+import com.codestates.hobby.global.exception.ExceptionCode;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -50,7 +52,7 @@ public class ShowcaseCommentService {
 	@Transactional(readOnly = true)
 	public ShowcaseComment findById(Long commentId) {
 		return commentRepository.findById(commentId)
-			.orElseThrow(() -> new IllegalArgumentException("Not found comment for " + commentId));
+			.orElseThrow(() -> new BusinessLogicException(ExceptionCode.COMMENT_NOT_FOUND));
 	}
 
 	@Transactional(readOnly = true)
@@ -66,6 +68,6 @@ public class ShowcaseCommentService {
 	private ShowcaseComment findVerifiedComment(long memberId, long showcaseId, long commentId) {
 		return commentRepository
 			.findByIdAndMemberIdAndShowcaseId(commentId, memberId, showcaseId)
-			.orElseThrow(() -> new IllegalArgumentException("Not found comment for " + commentId));
+			.orElseThrow(() -> new BusinessLogicException(ExceptionCode.COMMENT_NOT_FOUND));
 	}
 }

--- a/server/src/main/java/com/codestates/hobby/domain/showcase/service/ShowcaseService.java
+++ b/server/src/main/java/com/codestates/hobby/domain/showcase/service/ShowcaseService.java
@@ -1,5 +1,7 @@
 package com.codestates.hobby.domain.showcase.service;
 
+import com.codestates.hobby.global.exception.BusinessLogicException;
+import com.codestates.hobby.global.exception.ExceptionCode;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -35,7 +37,7 @@ public class ShowcaseService {
 	public Showcase update(ShowcaseDto.Patch patch) {
 		Category category = categoryService.findHobbyByName(patch.getCategory());
 		Showcase showcase = showcaseRepository.findByIdAndMemberId(patch.getShowcaseId(), patch.getMemberId())
-			.orElseThrow(() -> new IllegalArgumentException("Not Found showcase for " + patch.getShowcaseId()));
+			.orElseThrow(() -> new BusinessLogicException(ExceptionCode.SHOWCASE_NOT_FOUND));
 
 		showcase.update(category, patch.getContent(), patch.getImageUrls());
 
@@ -50,7 +52,7 @@ public class ShowcaseService {
 	@Transactional(readOnly = true)
 	public Showcase findById(long showcaseId) {
 		return showcaseRepository.findById(showcaseId)
-			.orElseThrow(() -> new IllegalArgumentException("Not found for " + showcaseId));
+			.orElseThrow(() -> new BusinessLogicException(ExceptionCode.SHOWCASE_NOT_FOUND));
 	}
 
 	@Transactional(readOnly = true)

--- a/server/src/main/java/com/codestates/hobby/global/advice/GlobalExceptionAdvice.java
+++ b/server/src/main/java/com/codestates/hobby/global/advice/GlobalExceptionAdvice.java
@@ -1,0 +1,36 @@
+package com.codestates.hobby.global.advice;
+
+import com.codestates.hobby.global.exception.BusinessLogicException;
+import com.codestates.hobby.global.response.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import javax.validation.ConstraintViolationException;
+
+@RestControllerAdvice
+public class GlobalExceptionAdvice {
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse  NotValidException(MethodArgumentNotValidException e){
+        final ErrorResponse response = ErrorResponse.of(e.getBindingResult());
+        return response;
+    }
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse ConstraintViolationException(ConstraintViolationException e) {
+        final ErrorResponse response = ErrorResponse.of(e.getConstraintViolations());
+        return response;
+    }
+
+    @ExceptionHandler
+    public ResponseEntity handleBusinessLogicException(BusinessLogicException e) {
+        System.out.println(e.getExceptionCode().getStatus());
+        System.out.println(e.getMessage());
+        return new ResponseEntity<>(HttpStatus.valueOf(e.getExceptionCode()
+                .getStatus()));
+    }
+}

--- a/server/src/main/java/com/codestates/hobby/global/exception/BusinessLogicException.java
+++ b/server/src/main/java/com/codestates/hobby/global/exception/BusinessLogicException.java
@@ -1,0 +1,13 @@
+package com.codestates.hobby.global.exception;
+
+import lombok.Getter;
+
+public class BusinessLogicException extends RuntimeException {
+    @Getter
+    private ExceptionCode exceptionCode;
+
+    public BusinessLogicException(ExceptionCode exceptionCode) {
+        super(exceptionCode.getMessage());
+        this.exceptionCode = exceptionCode;
+    }
+}

--- a/server/src/main/java/com/codestates/hobby/global/exception/ExceptionCode.java
+++ b/server/src/main/java/com/codestates/hobby/global/exception/ExceptionCode.java
@@ -1,0 +1,28 @@
+package com.codestates.hobby.global.exception;
+
+import lombok.Getter;
+
+public enum ExceptionCode {
+    MEMBER_NOT_FOUND(404, "Member Not Found"),
+    CATEGORY_NOT_FOUND(404, "Category Not Found"),
+    POST_NOT_FOUND(404, "Post Not Found"),
+    COMMENT_NOT_FOUND(404,"Comment Not Found"),
+    SERIES_NOT_FOUND(404,"Series Not Found"),
+    SHOWCASE_NOT_FOUND(404,"Showcase Not Found"),
+
+    WITHDRAWAL_MEMBER(500,"Member Is Withdrawn"),
+    EXISTS_EMAIL(500,"Email Is Exists"),
+    EXISTS_NICKNAME(500,"NickName Is Exists"),
+    NOT_MATCH_MEMBER(500, "Doesn't Belong This Member");
+
+    @Getter
+    private int status;
+
+    @Getter
+    private String message;
+
+    ExceptionCode(int status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/server/src/main/java/com/codestates/hobby/global/response/ErrorResponse.java
+++ b/server/src/main/java/com/codestates/hobby/global/response/ErrorResponse.java
@@ -1,0 +1,86 @@
+package com.codestates.hobby.global.response;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindingResult;
+
+import javax.validation.ConstraintViolation;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Getter
+public class ErrorResponse {
+    private int status;
+    private String message;
+    private List<FieldError> fieldErrors;
+    private List<ConstraintViolationError> violationErrors;
+
+    private ErrorResponse(int status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    private ErrorResponse(List<FieldError> fieldErrors, List<ConstraintViolationError> violationErrors) {
+        this.fieldErrors = fieldErrors;
+        this.violationErrors = violationErrors;
+    }
+
+    public static ErrorResponse of(BindingResult bindingResult) {
+        return new ErrorResponse(FieldError.of(bindingResult), null);
+    }
+
+    public static ErrorResponse of(Set<ConstraintViolation<?>> violations) {
+        return new ErrorResponse(null, ConstraintViolationError.of(violations));
+    }
+
+    public static ErrorResponse of(HttpStatus httpStatus) {
+        return new ErrorResponse(httpStatus.value(), httpStatus.getReasonPhrase());
+    }
+
+
+    @Getter
+    public static class FieldError {
+        private String field;
+        private Object rejectedValue;
+        private String reason;
+        private FieldError(String field, Object rejectedValue, String reason) {
+            this.field = field;
+            this.rejectedValue = rejectedValue;
+            this.reason = reason;
+    }
+
+    public static List<FieldError> of(BindingResult bindingResult){
+            final List<org.springframework.validation.FieldError> fieldErrors = bindingResult.getFieldErrors();
+            return fieldErrors.stream()
+                    .map(fieldError -> new FieldError(
+                            fieldError.getField(), fieldError.getRejectedValue() == null ? "" :
+                            fieldError.getRejectedValue().toString(),
+                            fieldError.getDefaultMessage()
+                    )).collect(Collectors.toList());
+        }
+    }
+    @Getter
+    public static class ConstraintViolationError{
+        private String propertyPath;
+        private Object rejectedValue;
+        private String reason;
+
+        private ConstraintViolationError(String propertyPath, Object rejectedValue,
+                                         String reason) {
+            this.propertyPath = propertyPath;
+            this.rejectedValue = rejectedValue;
+            this.reason = reason;
+        }
+
+        public static List<ConstraintViolationError> of(Set<ConstraintViolation<?>> constraintViolations){
+            return constraintViolations.stream()
+                    .map(constraintViolation -> new ConstraintViolationError(
+                            constraintViolation.getPropertyPath().toString(),
+                            constraintViolation.getInvalidValue().toString(),
+                            constraintViolation.getMessage()
+                    )).collect(Collectors.toList());
+        }
+
+    }
+}

--- a/server/src/test/java/com/codestates/hobby/domain/post/service/PostServiceTest.java
+++ b/server/src/test/java/com/codestates/hobby/domain/post/service/PostServiceTest.java
@@ -7,6 +7,7 @@ import com.codestates.hobby.domain.member.entity.Member;
 import com.codestates.hobby.domain.member.service.MemberService;
 import com.codestates.hobby.domain.post.dto.PostDto;
 import com.codestates.hobby.domain.post.entity.Post;
+import com.codestates.hobby.domain.post.mapper.PostMapper;
 import com.codestates.hobby.domain.post.repository.PostRepository;
 import com.codestates.hobby.domain.series.entity.Series;
 import com.codestates.hobby.domain.series.service.SeriesService;
@@ -17,6 +18,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
 
 
 import java.util.ArrayList;
@@ -40,6 +42,9 @@ public class PostServiceTest {
     @Mock
     static MemberService memberService;
 
+    @Autowired
+    static PostMapper postMapper;
+
     @Mock
     static CategoryService categoryService;
 
@@ -62,6 +67,7 @@ public class PostServiceTest {
             Category childCategory = Category.createChild("야구","baseball",patentCategory);
             Series series = new Series(member, "입문", childCategory, "Content");
             Post post = new Post(member,"Title",series,childCategory,"Content",urls);
+
 
             PostDto.Post postDto = new PostDto.Post();
 


### PR DESCRIPTION
## 변경사항
- 예외 처리를 클라이언트에게 전송하기 위해 GlobalExceptionAdvice 생성
- Custom Exception 생성
- 에러 코드와 response 생성
- Vaildation  에러 핸들링
- Serive 계층 예외 처리 수중
## 기타
- showcase와 category의 serivce 계층 에러를 수정하며, 속성값을 같이 보내주던 기존의 구현이 사라졌습니다. 혹시 필요하시다면 말씀 해주세요!
- setSeriesPostUrl 메서드를 Mapper로 이동하였습니다.