### PR TITLE
[BE/FileInfo] FileInfo 오류 수정

### DIFF
--- a/server/src/main/java/com/codestates/hobby/domain/fileInfo/entity/FileInfo.java
+++ b/server/src/main/java/com/codestates/hobby/domain/fileInfo/entity/FileInfo.java
@@ -96,10 +96,6 @@ public class FileInfo {
 		return fileURL.getToken(token);
 	}
 
-	public String getPath() {
-		return fileURL.getPath();
-	}
-
 	public String getFileURL() {
 		return fileURL.getFileUrl();
 	}
@@ -120,6 +116,14 @@ public class FileInfo {
 	@Override
 	public int hashCode() {
 		return fileURL != null ? fileURL.hashCode() : 0;
+	}
+
+	public void updateIndex(int index) {
+		this.index = index;
+	}
+
+	public void setSignedURL(String url) {
+		this.signedURL = url;
 	}
 
 	public enum TOKEN {

--- a/server/src/main/java/com/codestates/hobby/domain/fileInfo/entity/FileURL.java
+++ b/server/src/main/java/com/codestates/hobby/domain/fileInfo/entity/FileURL.java
@@ -53,12 +53,12 @@ public class FileURL {
 			: urlTokens.get(token.getIndex());
 	}
 
-	public String getPath() {
-		return String.join("/", urlTokens.get(3), urlTokens.get(4));
+	public ImageType getImageType() {
+		return ImageType.search(getToken(FileInfo.TOKEN.EXTENSION));
 	}
 
-	public ImageType getImageType() {
-		return ImageType.search(urlTokens.get(FileInfo.TOKEN.EXTENSION.getIndex()));
+	private String getPath() {
+		return String.join("/", urlTokens.get(3), urlTokens.get(4));
 	}
 
 	@Override

--- a/server/src/main/java/com/codestates/hobby/domain/fileInfo/mapper/FileInfoMapper.java
+++ b/server/src/main/java/com/codestates/hobby/domain/fileInfo/mapper/FileInfoMapper.java
@@ -14,4 +14,8 @@ public interface FileInfoMapper {
 			fileInfo.getSignedURL(),
 			fileInfo.getImageType());
 	}
+
+	default String map(FileInfo value) {
+		return value.getFileURL();
+	}
 }

--- a/server/src/main/java/com/codestates/hobby/domain/fileInfo/repository/FileInfoRepository.java
+++ b/server/src/main/java/com/codestates/hobby/domain/fileInfo/repository/FileInfoRepository.java
@@ -1,9 +1,13 @@
 package com.codestates.hobby.domain.fileInfo.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.codestates.hobby.domain.fileInfo.entity.FileInfo;
 
 public interface FileInfoRepository extends JpaRepository<FileInfo, Long> {
-	boolean existsByFileURL(String fileUrl);
+	boolean existsByFileURL_FileUrl(String fileUrl);
+
+	Optional<FileInfo> findByFileURL_FileUrl(String fileUrl);
 }

--- a/server/src/test/java/com/codestates/hobby/domain/fileInfo/service/FileInfoServiceTest.java
+++ b/server/src/test/java/com/codestates/hobby/domain/fileInfo/service/FileInfoServiceTest.java
@@ -67,7 +67,7 @@ class FileInfoServiceTest {
 			assertEquals(bucketName, info.getToken(FileInfo.TOKEN.BUCKET));
 			assertEquals("basepath", info.getToken(FileInfo.TOKEN.BASEPATH));
 			assertEquals("filename", info.getToken(FileInfo.TOKEN.FILENAME));
-			assertEquals(String.join("/", "basepath", "filename"), info.getPath());
+			assertEquals(String.join("/", "basepath", "filename"), info.getToken(FileInfo.TOKEN.PATH));
 		}
 
 		@Test
@@ -83,7 +83,7 @@ class FileInfoServiceTest {
 		FileRequestDto request = FileInfoStub.createRequest(0);
 		URL url = new URL("http", domain, "/");
 
-		given(repository.existsByFileURL(anyString())).willReturn(false);
+		given(repository.existsByFileURL_FileUrl(anyString())).willReturn(false);
 		given(storage.signUrl(any(), anyLong(), any(), ArgumentMatchers.<Storage.SignUrlOption>any())).willReturn(url);
 
 		// when
@@ -101,7 +101,7 @@ class FileInfoServiceTest {
 		List<FileRequestDto> requests = FileInfoStub.createRequests(0, 5);
 		URL url = new URL("http", domain, "/");
 
-		given(repository.existsByFileURL(anyString())).willReturn(false);
+		given(repository.existsByFileURL_FileUrl(anyString())).willReturn(false);
 		given(storage.signUrl(any(), anyLong(), any(), ArgumentMatchers.<Storage.SignUrlOption>any())).willReturn(url);
 
 		// when

--- a/server/src/test/java/com/codestates/hobby/domain/stub/FileInfoStub.java
+++ b/server/src/test/java/com/codestates/hobby/domain/stub/FileInfoStub.java
@@ -6,9 +6,9 @@ import java.util.stream.IntStream;
 
 import org.apache.commons.lang3.RandomUtils;
 
-import com.codestates.hobby.domain.fileInfo.dto.ImageType;
 import com.codestates.hobby.domain.fileInfo.dto.FileRequestDto;
 import com.codestates.hobby.domain.fileInfo.dto.FileResponseDto;
+import com.codestates.hobby.domain.fileInfo.dto.ImageType;
 import com.codestates.hobby.domain.fileInfo.entity.FileInfo;
 
 public class FileInfoStub {
@@ -45,8 +45,18 @@ public class FileInfoStub {
 			.collect(Collectors.toList());
 	}
 
-	public static FileInfo createEntity() {
+	public static FileResponseDto createUpdateResponse() {
+		return new FileResponseDto(
+			1,
+			"http://domain.com/bucket/basepath/file.png",
+			"SignedURL",
+			ImageType.PNG);
+	}
+
+	public static FileInfo createEntity(boolean isNew) {
 		String fileURL = "https://storage.cloud.google.com/intorest-images/basepath/filename.png";
-		return new FileInfo(ShowcaseStub.createShowcase(), fileURL, 0);
+		return isNew
+			? new FileInfo(fileURL, "SignedURL", 0)
+			: new FileInfo(ShowcaseStub.createShowcase(), fileURL, 0);
 	}
 }


### PR DESCRIPTION
## 변경사항
- `getPath()` 메서드 제거 
  - `Token`으로만 경로를 얻을 수 있게 변경
- `Repository` 메서드 변경
  - Embedded 타입인 `FileURL`에 맞춰서 수정함
- `GCSFileInfoService` 로직 변경 
  - 요청 타입[신규, 조회]에 대한 분기를 Service에서 처리하도록 수정함