### PR TITLE
[BE/Test] 테스트 유틸 클래스 분리

### DIFF
--- a/server/src/test/java/com/codestates/hobby/domain/category/controller/CategoryControllerTest.java
+++ b/server/src/test/java/com/codestates/hobby/domain/category/controller/CategoryControllerTest.java
@@ -29,7 +29,7 @@ class CategoryControllerTest extends ControllerTest {
 	List<CategoryDto.Response> response;
 
 	@BeforeAll
-	protected void beforeAll() {
+	protected void beforeAll() throws Exception {
 		super.beforeAll();
 		response = List.of(groupResponse());
 	}

--- a/server/src/test/java/com/codestates/hobby/utils/ControllerTest.java
+++ b/server/src/test/java/com/codestates/hobby/utils/ControllerTest.java
@@ -2,23 +2,24 @@ package com.codestates.hobby.utils;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 
+import java.lang.reflect.Constructor;
 import java.util.function.Supplier;
 
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
-import org.springframework.http.MediaType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
+import com.codestates.hobby.domain.auth.Session.SessionConst;
+import com.codestates.hobby.domain.member.entity.Member;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @MockBean(JpaMetamodelMappingContext.class)
@@ -31,15 +32,20 @@ public abstract class ControllerTest {
 	protected ObjectMapper om;
 
 	protected MockMvc mvc;
+	protected MockHttpSession session;
 
 	@BeforeAll
-	protected void beforeAll() {
-		mvc = MockMvcBuilders.webAppContextSetup(ctx).build();
-	}
+	protected void beforeAll() throws Exception {
+		Constructor<Member> constructor = Member.class.getDeclaredConstructor();
+		constructor.setAccessible(true);
 
-	@BeforeEach
-	void beforeEach() {
-		SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(1L, ""));
+		Member member = constructor.newInstance();
+		ReflectionTestUtils.setField(member, "id", 1L);
+
+		session = new MockHttpSession();
+		session.setAttribute(SessionConst.LOGIN_MEMBER, member);
+
+		mvc = MockMvcBuilders.webAppContextSetup(ctx).build();
 	}
 
 	public <T> ResultActions defaultPostActions(String path, T content, Object... uriVariables) throws Exception {
@@ -50,18 +56,19 @@ public abstract class ControllerTest {
 		return defaultActions(() -> patch(path, uriVariables), content);
 	}
 
-	private <T> ResultActions defaultActions(Supplier<MockHttpServletRequestBuilder> builder, T content) throws Exception {
+	private <T> ResultActions defaultActions(Supplier<MockHttpServletRequestBuilder> builder, T content) throws
+		Exception {
 		return mvc.perform(
-			builder.get()
-				.contentType(MediaType.APPLICATION_JSON)
-				.accept(MediaType.APPLICATION_JSON)
+			TestUtils.jsonBuilder(builder)
 				.content(om.writeValueAsString(content))
+				.session(session)
 		);
 	}
 
 	public ResultActions defaultActionsWithPaging(String path, Object... uriVariables) throws Exception {
 		return mvc.perform(
 			get(path, uriVariables)
+				.param("offset", "1")
 				.param("page", "1")
 				.param("size", "5")
 		);

--- a/server/src/test/java/com/codestates/hobby/utils/IntegrationTest.java
+++ b/server/src/test/java/com/codestates/hobby/utils/IntegrationTest.java
@@ -1,0 +1,92 @@
+package com.codestates.hobby.utils;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import com.codestates.hobby.domain.auth.Session.SessionConst;
+import com.codestates.hobby.domain.fileInfo.repository.FileInfoRepository;
+import com.codestates.hobby.domain.member.repository.MemberRepository;
+import com.codestates.hobby.domain.showcase.repository.ShowcaseRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"gcs"})
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public abstract class IntegrationTest {
+	@Autowired
+	private WebApplicationContext wac;
+
+	@Autowired
+	protected MemberRepository memberRepository;
+
+	@Autowired
+	protected FileInfoRepository fileInfoRepository;
+
+	@Autowired
+	protected ShowcaseRepository showcaseRepository;
+
+	@Autowired
+	protected ObjectMapper om;
+
+	protected MockHttpSession session;
+
+	protected MockMvc mvc;
+
+	@BeforeAll
+	void beforeAll() {
+		mvc = MockMvcBuilders.webAppContextSetup(wac)
+			.apply(springSecurity())
+			.build();
+
+		initSession();
+	}
+
+	protected void initSession() {
+		session = new MockHttpSession();
+		session.setAttribute(SessionConst.LOGIN_MEMBER, memberRepository.findAll().get(0));
+	}
+
+	protected ResultActions defaultPostActions(String endPoint, Object content, Object... variables) throws Exception {
+		return mvc.perform(defaultActions(() -> post(endPoint, variables), content));
+	}
+
+	protected ResultActions defaultPatchActions(String endPoint, Object content, Object... variables) throws Exception {
+		return mvc.perform(defaultActions(() -> patch(endPoint, variables), content));
+	}
+
+	protected ResultActions defaultPagingActions(String endPoint, int page, int size, Object... variables) throws Exception {
+		return mvc.perform(
+			get(endPoint, variables)
+				.param("page", String.valueOf(page))
+				.param("size", String.valueOf(size))
+				.session(session)
+		);
+	}
+
+	private <T> MockHttpServletRequestBuilder defaultActions(Supplier<MockHttpServletRequestBuilder> builder, T content) throws Exception {
+		return TestUtils.jsonBuilder(builder)
+			.session(session)
+			.content(om.writeValueAsString(content))
+			.characterEncoding(StandardCharsets.UTF_8);
+	}
+}

--- a/server/src/test/java/com/codestates/hobby/utils/TestUtils.java
+++ b/server/src/test/java/com/codestates/hobby/utils/TestUtils.java
@@ -1,0 +1,16 @@
+package com.codestates.hobby.utils;
+
+import java.nio.charset.StandardCharsets;
+import java.util.function.Supplier;
+
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+public class TestUtils {
+	public static <T> MockHttpServletRequestBuilder jsonBuilder(Supplier<MockHttpServletRequestBuilder> builder) {
+		return builder.get()
+			.accept(MediaType.APPLICATION_JSON)
+			.contentType(MediaType.APPLICATION_JSON)
+			.characterEncoding(StandardCharsets.UTF_8);
+	}
+}


### PR DESCRIPTION
## 개요
- 통합테스트 전용 추상클래스 구현
- 테스트용 유틸 클래스 구현

## 작업내용
- 통합테스트할 때 `IntegrationTest`를 상속받으시면 됩니다.