### PR TITLE
[BE/Mail] 이메일 전송 기능 구현

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+**/env.properties
 
 ### STS ###
 .apt_generated

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -24,8 +24,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
     // 캐시
     implementation 'org.hibernate:hibernate-jcache:5.6.14.Final'
@@ -38,8 +39,6 @@ dependencies {
     implementation 'com.google.code.gson:gson'
 
     // 클라우드 스토리지
-    // implementation 'org.springframework.cloud:spring-cloud-gcp-starter:1.2.8.RELEASE'
-    // -> application.yml에 key 위치만 명시하면 자동설정돼서 편하지만, 잡다한 라이브러리들을 의존함
     implementation 'org.springframework.cloud:spring-cloud-gcp-storage:1.2.8.RELEASE'
 
     runtimeOnly 'com.h2database:h2'

--- a/server/src/main/java/com/codestates/hobby/ServerApplication.java
+++ b/server/src/main/java/com/codestates/hobby/ServerApplication.java
@@ -2,10 +2,12 @@ package com.codestates.hobby;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @SpringBootApplication
+@PropertySource("classpath:env.properties")
 public class ServerApplication {
 
 	public static void main(String[] args) {

--- a/server/src/main/java/com/codestates/hobby/domain/auth/entity/Certification.java
+++ b/server/src/main/java/com/codestates/hobby/domain/auth/entity/Certification.java
@@ -1,7 +1,4 @@
-package com.codestates.hobby.domain.certification.entity;
-
-import java.time.LocalDateTime;
-import java.util.Random;
+package com.codestates.hobby.domain.auth.entity;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;

--- a/server/src/main/java/com/codestates/hobby/domain/auth/event/CertificationCreatedEvent.java
+++ b/server/src/main/java/com/codestates/hobby/domain/auth/event/CertificationCreatedEvent.java
@@ -1,0 +1,14 @@
+package com.codestates.hobby.domain.auth.event;
+
+import lombok.Getter;
+
+@Getter
+public class CertificationCreatedEvent {
+	private final String email;
+	private final int code;
+
+	public CertificationCreatedEvent(String email, int code) {
+		this.email = email;
+		this.code = code;
+	}
+}

--- a/server/src/main/java/com/codestates/hobby/domain/auth/service/CertificationEventHandler.java
+++ b/server/src/main/java/com/codestates/hobby/domain/auth/service/CertificationEventHandler.java
@@ -1,0 +1,32 @@
+package com.codestates.hobby.domain.auth.service;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+import com.codestates.hobby.domain.auth.event.CertificationCreatedEvent;
+import com.codestates.hobby.global.support.mail.EmailService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CertificationEventHandler {
+	private static final String TEMPLATE = "email-certification-template";
+	private static final String SUBJECT = "Please certify your email";
+
+	private final TemplateEngine templateEngine;
+	private final EmailService emailService;
+
+	@TransactionalEventListener
+	public void handleCertificationCreatedEvent(CertificationCreatedEvent event) {
+		Context context = new Context();
+		context.setVariable("code", event.getCode());
+
+		String html = templateEngine.process(TEMPLATE, context);
+		emailService.send(event.getEmail(), SUBJECT, html);
+	}
+}

--- a/server/src/main/java/com/codestates/hobby/global/config/GCSConfig.java
+++ b/server/src/main/java/com/codestates/hobby/global/config/GCSConfig.java
@@ -16,7 +16,7 @@ public class GCSConfig {
 	@Bean
 	public Storage storage() throws IOException {
 		GoogleCredentials credentials =
-			GoogleCredentials.fromStream(getClass().getResourceAsStream("/intorest-ea8d5b9d1484.json"));
+			GoogleCredentials.fromStream(getClass().getResourceAsStream("/key.json"));
 
 		return StorageOptions.newBuilder().setProjectId("intorest")
 			.setCredentials(credentials)

--- a/server/src/main/java/com/codestates/hobby/global/support/mail/EmailService.java
+++ b/server/src/main/java/com/codestates/hobby/global/support/mail/EmailService.java
@@ -1,0 +1,5 @@
+package com.codestates.hobby.global.support.mail;
+
+public interface EmailService {
+	void send(String to, String subject, String text);
+}

--- a/server/src/main/java/com/codestates/hobby/global/support/mail/GoogleEmailService.java
+++ b/server/src/main/java/com/codestates/hobby/global/support/mail/GoogleEmailService.java
@@ -26,9 +26,8 @@ public class GoogleEmailService implements EmailService {
 		try {
 			MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
 			mimeMessageHelper.setTo(to);
-			mimeMessageHelper.setSubject(subject);
-
 			mimeMessageHelper.setText(text, true);
+			mimeMessageHelper.setSubject(subject);
 
 			mailSender.send(mimeMessage);
 			log.info("sent email (to: {}, subject: {})", to, subject);

--- a/server/src/main/java/com/codestates/hobby/global/support/mail/GoogleEmailService.java
+++ b/server/src/main/java/com/codestates/hobby/global/support/mail/GoogleEmailService.java
@@ -1,0 +1,39 @@
+package com.codestates.hobby.global.support.mail;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@Profile("!mock")
+@RequiredArgsConstructor
+public class GoogleEmailService implements EmailService {
+	private final JavaMailSender mailSender;
+
+	@Async
+	public void send(String to, String subject, String text) {
+		MimeMessage mimeMessage = mailSender.createMimeMessage();
+
+		try {
+			MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+			mimeMessageHelper.setTo(to);
+			mimeMessageHelper.setSubject(subject);
+
+			mimeMessageHelper.setText(text, true);
+
+			mailSender.send(mimeMessage);
+			log.info("sent email (to: {}, subject: {})", to, subject);
+		} catch (MessagingException e) {
+			log.error("exception occured: {}", e.getMessage());
+		}
+	}
+}

--- a/server/src/main/java/com/codestates/hobby/global/support/mail/MockEmailService.java
+++ b/server/src/main/java/com/codestates/hobby/global/support/mail/MockEmailService.java
@@ -1,0 +1,17 @@
+package com.codestates.hobby.global.support.mail;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@Profile("mock")
+@RequiredArgsConstructor
+public class MockEmailService implements EmailService {
+	public void send(String to, String subject, String text) {
+		log.info("Sent email (to: {}, subject: {}, text: {})", to, subject, text);
+	}
+}

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -31,6 +31,17 @@ spring:
   output:
     ansi:
       enabled: always
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${EMAIL_USERNAME}
+    password: ${EMAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
 
 cloud:
   storage:

--- a/server/src/main/resources/templates/email-certification-template.html
+++ b/server/src/main/resources/templates/email-certification-template.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Please certify your email</title>
+</head>
+<body>
+<div>
+    <p>Please certify your email</p>
+
+    <p>Cerification code: <b>[[${code}]]</b></p>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## 작업내용
- 구글 기반 이메일 전송 기능 구현
- Certification 생성 이벤트와 핸들러 구현

## 기타
- profile('mock')을 지정하지 않을시 구글 서비스가 지정됩니다.
  - mock 프로파일을 지정하고 실행해야됩니다.
- 구글 이메일 기능을 실행하기 위해서는 앱 비밀번호가 설정된 구글 이메일이 필요합니다. [link](https://support.bespinglobal.com/ko/support/solutions/articles/73000545275--gmail-%EC%95%B1-%EB%B9%84%EB%B0%80%EB%B2%88%ED%98%B8-%EC%83%9D%EC%84%B1%EB%B0%A9%EB%B2%95)