### PR TITLE
[Be/Post, Series] post, series 엔티티 및 DB 구성 방식 변경 

### DIFF
--- a/server/src/main/java/com/codestates/hobby/domain/auth/controller/HomeController.java
+++ b/server/src/main/java/com/codestates/hobby/domain/auth/controller/HomeController.java
@@ -1,7 +1,6 @@
 package com.codestates.hobby.domain.auth.controller;
 
 import com.codestates.hobby.domain.auth.Session.SessionConst;
-import com.codestates.hobby.domain.auth.Session.SessionManager;
 import com.codestates.hobby.domain.member.entity.Member;
 import com.codestates.hobby.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +15,6 @@ import javax.servlet.http.HttpSession;
 @RequiredArgsConstructor
 public class HomeController {
     private final MemberRepository memberRepository;
-    private final SessionManager sessionManager;
 
     @GetMapping("/")
     public String homeLogin(HttpServletRequest request, Model model) {

--- a/server/src/main/java/com/codestates/hobby/domain/common/Writing.java
+++ b/server/src/main/java/com/codestates/hobby/domain/common/Writing.java
@@ -1,0 +1,52 @@
+package com.codestates.hobby.domain.common;
+
+import com.codestates.hobby.domain.category.entity.Category;
+import com.codestates.hobby.domain.member.entity.Member;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@Inheritance(strategy= InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn
+@NoArgsConstructor
+public abstract class Writing extends BaseEntity{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "MEDIUMTEXT")
+    private String content;
+
+    @Column
+    @ColumnDefault("0")
+    private int views;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
+    public Writing(Member member, String title, Category category, String content){
+        this.member = member;
+        this.title = title;
+        this.category = category;
+        this.content = content;
+    }
+
+    public void  update(String title, String content, Category category){
+        this.title = title;
+        this.content = content;
+        this.category = category;
+    }
+
+}

--- a/server/src/main/java/com/codestates/hobby/domain/post/dto/PostCommentDto.java
+++ b/server/src/main/java/com/codestates/hobby/domain/post/dto/PostCommentDto.java
@@ -50,7 +50,7 @@ public class PostCommentDto {
         private long id;
         private String content;
         private LocalDateTime createdAt;
-        private LocalDateTime lastModifiedAt;
+        private LocalDateTime modifiedAt;
         private MemberDto.SimpleResponse writer;
     }
 }

--- a/server/src/main/java/com/codestates/hobby/domain/post/entity/Post.java
+++ b/server/src/main/java/com/codestates/hobby/domain/post/entity/Post.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.persistence.*;
 
+import com.codestates.hobby.domain.common.Writing;
 import org.hibernate.annotations.ColumnDefault;
 
 import com.codestates.hobby.domain.category.entity.Category;
@@ -20,29 +21,9 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@DiscriminatorValue("Post")
 @NoArgsConstructor
-public class Post extends BaseEntity {
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
-
-	@Column(nullable = false)
-	private String title;
-
-	@Column(nullable = false, columnDefinition = "MEDIUMTEXT")
-	private String content;
-
-	@Column
-	@ColumnDefault("0")
-	private int views;
-
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "member_id", nullable = false)
-	private Member member;
-
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "category_id", nullable = false)
-	private Category category;
+public class Post extends Writing {
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "series_id")
@@ -67,44 +48,32 @@ public class Post extends BaseEntity {
 	}
 
 	public Post(Member member, String title, Series series, Category category, String content, List<String> imageURLs) {
-		this.member = member;
-		this.title = title;
-		this.content = content;
-		this.category = category;
+		super(member, title, category, content);
 		this.series = series;
 
 		if (imageURLs == null) this.images = null;
 		else imageURLs.forEach(this::addImageFromUrl);
-
-
 	}
 
 	public void updatePost (String title, String content, Category category, Series series, List<String> imageURLs) {
-		this.title = title;
-		this.content = content;
-		this.category = category;
+		super.update(title, content, category);
 		this.series = series;
-		updateImage(imageURLs);
+
+		if (imageURLs == null) this.images = null;
+		else updateImage(imageURLs);
 	}
 
 	public void updatePost (String title, String content, Category category, Series series) {
-		this.title = title;
-		this.content = content;
-		this.category = category;
-		this.series = series;
+		this.updatePost(title, content, category, series, null);
 	}
 
 	public void updatePost (String title, String content, Category category, List<String> imageURLs) {
-		this.title = title;
-		this.content = content;
-		this.category = category;
-		updateImage(imageURLs);
+		this.updatePost(title, content, category, null, imageURLs);
 	}
 
 	public void updatePost (String title, String content, Category category) {
-		this.title = title;
-		this.content = content;
-		this.category = category;
+		this.updatePost(title, content, category, null, null);
+
 	}
 
 	public void addImageFromUrl(String url) {

--- a/server/src/main/java/com/codestates/hobby/domain/post/mapper/PostCommentMapper.java
+++ b/server/src/main/java/com/codestates/hobby/domain/post/mapper/PostCommentMapper.java
@@ -10,7 +10,7 @@ import org.mapstruct.Mapping;
 import java.util.List;
 import java.util.Optional;
 
-@Mapper(componentModel = "spring",  uses = {MemberMapper.class, PostCommentMapper.class})
+@Mapper(componentModel = "spring",  uses = {MemberMapper.class})
 public interface PostCommentMapper {
     @Mapping(target = "writer", source = "member")
     PostCommentDto.Response postCommentToPostCommentResponse(PostComment comment);

--- a/server/src/main/java/com/codestates/hobby/domain/series/entity/Series.java
+++ b/server/src/main/java/com/codestates/hobby/domain/series/entity/Series.java
@@ -3,18 +3,9 @@ package com.codestates.hobby.domain.series.entity;
 import java.util.List;
 import java.util.Optional;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
+import javax.persistence.*;
 
+import com.codestates.hobby.domain.common.Writing;
 import com.codestates.hobby.domain.fileInfo.entity.FileInfo;
 import org.hibernate.annotations.ColumnDefault;
 
@@ -29,30 +20,9 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@DiscriminatorValue("Series")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Series extends BaseEntity {
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
-
-	@Column(nullable = false)
-	private String title;
-
-	@Column(nullable = false)
-	private String content;
-
-	@Column
-	@ColumnDefault("0")
-	private int views;
-
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "member_id", nullable = false, updatable = false)
-	private Member member;
-
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "category_id", nullable = false)
-	private Category category;
-
+public class Series extends Writing {
 	@OneToMany(mappedBy = "series")
 	private List<Post> posts;
 
@@ -61,17 +31,12 @@ public class Series extends BaseEntity {
 	private FileInfo image;
 
 	public Series(Member member, Category category, String title, String content, String thumbnail) {
-		this.member = member;
-		this.category = category;
-		this.title = title;
-		this.content = content;
+		super(member, title, category, content);
 		this.changeImage(thumbnail);
 	}
 
 	public void edit(Category category, String title, String content, String thumbnail) {
-		if(!this.category.getId().equals(category.getId()))  this.category = category;
-		if(Optional.ofNullable(title).isPresent()) this.title = title;
-		if(Optional.ofNullable(content).isPresent()) this.content = content;
+		super.update(title, content, category);
 		if(Optional.ofNullable(thumbnail).isPresent()) changeImage(thumbnail);
 	}
 

--- a/server/src/test/java/com/codestates/hobby/domain/post/controller/PostCommentControllerTest.java
+++ b/server/src/test/java/com/codestates/hobby/domain/post/controller/PostCommentControllerTest.java
@@ -72,7 +72,7 @@ public class PostCommentControllerTest {
         member = new Member("aaa@gmail.com",
                 "홍길동",
                 "Codestates11!","introduction",
-                false, "http://domain.com/bucket/basepath/file.png");
+                false, "http://domain.com/bucket/basepath/file.png",List.of("role"));
         fileInfo = member.getImage();
         patentCategory = Category.createParent("운동","exercise");
         childCategory = Category.createChild("야구","baseball",patentCategory);
@@ -147,9 +147,8 @@ public class PostCommentControllerTest {
         response.setId(1L);
         response.setContent("Content");
         response.setWriter(null);
-        response.setItWriter(true);
         response.setCreatedAt(LocalDateTime.now());
-        response.setLastModifiedAt(LocalDateTime.now());
+        response.setModifiedAt(LocalDateTime.now());
         PostComment postComment = new PostComment("Comment", member, post);
 
         //Comment를 Page로 주는게 맞나??..
@@ -159,7 +158,6 @@ public class PostCommentControllerTest {
 
         given(postCommentService.findAll(anyLong(),any(PageRequest.class))).willReturn(pageComment);
         given(postCommentMapper.postCommentToPostCommentResponse(any(PostComment.class))).willReturn(response);
-        willDoNothing().given(postCommentMapper).setProperties(any(PostCommentDto.Response.class), anyLong());
 
         ResultActions actions = mockMvc.perform(
                 get("/posts/{post-id}/comments",1)

--- a/server/src/test/java/com/codestates/hobby/domain/post/controller/PostControllerTest.java
+++ b/server/src/test/java/com/codestates/hobby/domain/post/controller/PostControllerTest.java
@@ -70,7 +70,7 @@ public class PostControllerTest {
         member = new Member("aaa@gmail.com",
             "홍길동",
             "Codestates11!","introduction",
-            false, "http://domain.com/bucket/basepath/file.png");
+            false, "http://domain.com/bucket/basepath/file.png",List.of("role"));
         fileInfo = member.getImage();
         patentCategory = Category.createParent("운동","exercise");
         childCategory = Category.createChild("야구","baseball",patentCategory);
@@ -151,10 +151,9 @@ public class PostControllerTest {
         PostCommentDto.Response commentDto = new PostCommentDto.Response();
         commentDto.setId(1L);
         commentDto.setWriter(null);
-        commentDto.setItWriter(true);
         commentDto.setContent("comment");
         commentDto.setCreatedAt(LocalDateTime.now());
-        commentDto.setLastModifiedAt(LocalDateTime.now());
+        commentDto.setModifiedAt(LocalDateTime.now());
 
         PostDto.Response response = new PostDto.Response();
 
@@ -163,10 +162,9 @@ public class PostControllerTest {
         response.setId(1L);
         response.setTitle("Title");
         response.setContent("Content");
-        response.setItWriter(true);
         response.setViews(10);
-        response.setCreatedDate(LocalDateTime.now());
-        response.setModifiedDate(LocalDateTime.now());
+        response.setCreatedAt(LocalDateTime.now());
+        response.setModifiedAt(LocalDateTime.now());
         response.setCategory("야구");
         response.setSeriesId(1L);
         response.setComments(List.of(commentDto));
@@ -191,10 +189,9 @@ public class PostControllerTest {
         simpleResponse.setId(1L);
         simpleResponse.setTitle("Title");
         simpleResponse.setContent("Content");
-        simpleResponse.setItWriter(true);
         simpleResponse.setViews(10);
-        simpleResponse.setCreatedDate(LocalDateTime.now());
-        simpleResponse.setModifiedDate(LocalDateTime.now());
+        simpleResponse.setCreatedAt(LocalDateTime.now());
+        simpleResponse.setModifiedAt(LocalDateTime.now());
         simpleResponse.setCategory("야구");
         simpleResponse.setSeriesId(1L);
         simpleResponse.setComments(10);
@@ -207,7 +204,6 @@ public class PostControllerTest {
 
         given(postService.findAll(any(PageRequest.class))).willReturn(pagePost);
         given(postMapper.postToSimpleResponse(any(Post.class))).willReturn(simpleResponse);
-        willDoNothing().given(postMapper).setProperties(any(PostDto.Response.class), anyLong());
 
         ResultActions actions = mockMvc.perform(
                 get("/posts")
@@ -229,10 +225,9 @@ public class PostControllerTest {
         simpleResponse.setId(1L);
         simpleResponse.setTitle("Title");
         simpleResponse.setContent("Content");
-        simpleResponse.setItWriter(true);
         simpleResponse.setViews(10);
-        simpleResponse.setCreatedDate(LocalDateTime.now());
-        simpleResponse.setModifiedDate(LocalDateTime.now());
+        simpleResponse.setCreatedAt(LocalDateTime.now());
+        simpleResponse.setModifiedAt(LocalDateTime.now());
         simpleResponse.setCategory("야구");
         simpleResponse.setSeriesId(1L);
         simpleResponse.setComments(10);
@@ -245,7 +240,6 @@ public class PostControllerTest {
 
         given(postService.findAllByCategory(anyString(),any(PageRequest.class))).willReturn(pagePost);
         given(postMapper.postToSimpleResponse(any(Post.class))).willReturn(simpleResponse);
-        willDoNothing().given(postMapper).setProperties(any(PostDto.Response.class), anyLong());
 
         ResultActions actions = mockMvc.perform(
                 get("/categories/{category-name}/posts", 1)
@@ -266,10 +260,9 @@ public class PostControllerTest {
         simpleResponse.setId(1L);
         simpleResponse.setTitle("Title");
         simpleResponse.setContent("Content");
-        simpleResponse.setItWriter(true);
         simpleResponse.setViews(10);
-        simpleResponse.setCreatedDate(LocalDateTime.now());
-        simpleResponse.setModifiedDate(LocalDateTime.now());
+        simpleResponse.setCreatedAt(LocalDateTime.now());
+        simpleResponse.setModifiedAt(LocalDateTime.now());
         simpleResponse.setCategory("야구");
         simpleResponse.setSeriesId(1L);
         simpleResponse.setComments(10);
@@ -282,7 +275,6 @@ public class PostControllerTest {
 
         given(postService.findAllBySeries(anyLong(),any(PageRequest.class))).willReturn(pagePost);
         given(postMapper.postToSimpleResponse(any(Post.class))).willReturn(simpleResponse);
-        willDoNothing().given(postMapper).setProperties(any(PostDto.Response.class), anyLong());
 
         ResultActions actions = mockMvc.perform(
                 get("/series/{series-id}/posts", 1)
@@ -303,10 +295,9 @@ public class PostControllerTest {
         simpleResponse.setId(1L);
         simpleResponse.setTitle("Title");
         simpleResponse.setContent("Content");
-        simpleResponse.setItWriter(true);
         simpleResponse.setViews(10);
-        simpleResponse.setCreatedDate(LocalDateTime.now());
-        simpleResponse.setModifiedDate(LocalDateTime.now());
+        simpleResponse.setCreatedAt(LocalDateTime.now());
+        simpleResponse.setModifiedAt(LocalDateTime.now());
         simpleResponse.setCategory("야구");
         simpleResponse.setSeriesId(1L);
         simpleResponse.setComments(10);
@@ -319,7 +310,6 @@ public class PostControllerTest {
 
         given(postService.findAllByMember(anyLong(),any(PageRequest.class))).willReturn(pagePost);
         given(postMapper.postToSimpleResponse(any(Post.class))).willReturn(simpleResponse);
-        willDoNothing().given(postMapper).setProperties(any(PostDto.Response.class), anyLong());
 
         ResultActions actions = mockMvc.perform(
                 get("/members/{member-id}/posts", 1)

--- a/server/src/test/java/com/codestates/hobby/domain/post/service/PostServiceTest.java
+++ b/server/src/test/java/com/codestates/hobby/domain/post/service/PostServiceTest.java
@@ -61,7 +61,7 @@ public class PostServiceTest {
             Member member = new Member("aaa@gmail.com",
                 "홍길동",
                 "Codestates11!","introduction",
-                false, "http://domain.com/bucket/basepath/file.png");
+                false, "http://domain.com/bucket/basepath/file.png", List.of("TestUser"));
             Category patentCategory = Category.createParent("운동","exercise");
             Category childCategory = Category.createChild("야구","baseball",patentCategory);
             Series series = new Series(member, childCategory, "입문", "Content", urls.get(0));
@@ -97,7 +97,7 @@ public class PostServiceTest {
             Member member = new Member("aaa@gmail.com",
                     "홍길동",
                     "Codestates11!","introduction",
-                    false, "http://domain.com/bucket/basepath/file.png");
+                    false, "http://domain.com/bucket/basepath/file.png", List.of("TestUser"));
 
             Category patentCategory = Category.createParent("운동","exercise");
             Category childCategory = Category.createChild("야구","baseball",patentCategory);

--- a/server/src/test/java/com/codestates/hobby/domain/post/tempTest/AsyncTest.java
+++ b/server/src/test/java/com/codestates/hobby/domain/post/tempTest/AsyncTest.java
@@ -1,0 +1,64 @@
+package com.codestates.hobby.domain.post.tempTest;
+
+import com.codestates.hobby.domain.category.entity.Category;
+import com.codestates.hobby.domain.category.repository.CategoryRepository;
+import com.codestates.hobby.domain.member.entity.Member;
+import com.codestates.hobby.domain.member.repository.MemberRepository;
+import com.codestates.hobby.domain.post.dto.PostDto;
+import com.codestates.hobby.domain.post.entity.Post;
+import com.codestates.hobby.domain.post.repository.PostRepository;
+import com.codestates.hobby.domain.post.service.PostService;
+import com.codestates.hobby.domain.series.entity.Series;
+import com.codestates.hobby.domain.series.repository.SeriesRepository;
+import com.codestates.hobby.global.config.support.CustomPageRequest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+import java.util.Optional;
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class AsyncTest {
+    @Autowired
+    private PostService postService;
+    @Autowired
+    private PostRepository postRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private CategoryRepository categoryRepository;
+    @Autowired
+    private SeriesRepository seriesRepository;
+
+
+    @BeforeEach
+    void setUp(){
+        List<String> urls = List.of("http://domain.com/bucket/possdftsa/filsdfeasd.png");
+        Member member = new Member("aaa@gmail.com",
+                "홍길동",
+                "Codestates11!", "introduction",
+                false, "http://domain.com/buckekkkt/basekkkpath/file.png", List.of("TestUser"));
+        Category category = categoryRepository.findById(1L).get();
+        Series series = new Series(member, category, "입문", "Content", urls.get(0));
+        memberRepository.save(member);
+        seriesRepository.save(series);
+    }
+
+
+    @Test
+    public void 포스트_생성(){
+        PostDto.Post post = new PostDto.Post();
+        post.setMemberId(1L);
+        post.setTitle("title");
+        post.setContent("content");
+        post.setCategory("movie");
+        post.setSeriesId(1L);
+        postService.post(post);
+    }
+}


### PR DESCRIPTION
## 변경사항
- Post와 Series 테이블을 Super-Type Writing의 Sub-Type으로 변경
- 각 엔티티도 상속을 통해 구현
##기타
- 이제 Post 및 Series는 Writing 클래스의 DTYPE 속성을 통해 구별되며, 비즈니스 로직의 변경 사항은 없습니다.