### PR TITLE
[BE/Deploy] 배포를 위한 Profile 재설정

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -25,6 +25,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
+
+    // 메일
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
@@ -42,6 +44,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-gcp-storage:1.2.8.RELEASE'
 
     runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'mysql:mysql-connector-java'
     compileOnly 'org.projectlombok:lombok'
 
     annotationProcessor 'org.projectlombok:lombok'

--- a/server/src/main/java/com/codestates/hobby/ServerApplication.java
+++ b/server/src/main/java/com/codestates/hobby/ServerApplication.java
@@ -2,14 +2,11 @@ package com.codestates.hobby;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.PropertySource;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @SpringBootApplication
-@PropertySource("classpath:env.properties")
 public class ServerApplication {
-
 	public static void main(String[] args) {
 		SpringApplication.run(ServerApplication.class, args);
 	}

--- a/server/src/main/java/com/codestates/hobby/domain/common/BaseEntity.java
+++ b/server/src/main/java/com/codestates/hobby/domain/common/BaseEntity.java
@@ -19,11 +19,11 @@ import lombok.Getter;
 public abstract class BaseEntity {
 	@CreatedDate
 	@ColumnDefault(value = "CURRENT_TIMESTAMP")
-	@Column(nullable = false, updatable = false)
+	@Column(nullable = false, updatable = false, columnDefinition = "timestamp")
 	private LocalDateTime createdAt;
 
 	@LastModifiedDate
 	@ColumnDefault(value = "CURRENT_TIMESTAMP")
-	@Column(nullable = false)
+	@Column(nullable = false, columnDefinition = "timestamp")
 	private LocalDateTime modifiedAt;
 }

--- a/server/src/main/java/com/codestates/hobby/domain/fileInfo/entity/FileInfo.java
+++ b/server/src/main/java/com/codestates/hobby/domain/fileInfo/entity/FileInfo.java
@@ -40,7 +40,7 @@ public class FileInfo {
 	@Transient
 	private String signedURL;
 
-	@Column(columnDefinition = "int(11)")
+	@Column(columnDefinition = "TINYINT")
 	private int fileIndex;
 
 	@Column(nullable = false, updatable = false, columnDefinition = "timestamp")

--- a/server/src/main/java/com/codestates/hobby/domain/fileInfo/entity/FileInfo.java
+++ b/server/src/main/java/com/codestates/hobby/domain/fileInfo/entity/FileInfo.java
@@ -40,9 +40,10 @@ public class FileInfo {
 	@Transient
 	private String signedURL;
 
-	private Integer index;
+	@Column(columnDefinition = "int(11)")
+	private int fileIndex;
 
-	@Column(nullable = false, updatable = false)
+	@Column(nullable = false, updatable = false, columnDefinition = "timestamp")
 	private LocalDateTime createdAt = LocalDateTime.now();
 
 	@Setter
@@ -62,34 +63,34 @@ public class FileInfo {
 	@JoinColumn(name = "showcase_id", updatable = false)
 	private Showcase showcase;
 
-	public FileInfo(String fileURL, String signedURL, Integer index) {
+	public FileInfo(String fileURL, String signedURL, Integer fileIndex) {
 		this.fileURL = new FileURL(fileURL);
 		this.signedURL = signedURL;
-		this.index = index;
+		this.fileIndex = fileIndex;
 	}
 
-	public FileInfo(Member member, String fileURL, int index) {
+	public FileInfo(Member member, String fileURL, int fileIndex) {
 		this.fileURL = new FileURL(fileURL);
 		this.member = member;
-		this.index = index;
+		this.fileIndex = fileIndex;
 	}
 
-	public FileInfo(Series series, String fileURL, int index) {
+	public FileInfo(Series series, String fileURL, int fileIndex) {
 		this.fileURL = new FileURL(fileURL);
 		this.series = series;
-		this.index = index;
+		this.fileIndex = fileIndex;
 	}
 
-	public FileInfo(Post post, String fileURL, int index) {
+	public FileInfo(Post post, String fileURL, int fileIndex) {
 		this.fileURL = new FileURL(fileURL);
-		this.index = index;
+		this.fileIndex = fileIndex;
 		this.post = post;
 	}
 
-	public FileInfo(Showcase showcase, String fileURL, int index) {
+	public FileInfo(Showcase showcase, String fileURL, int fileIndex) {
 		this.fileURL = new FileURL(fileURL);
 		this.showcase = showcase;
-		this.index = index;
+		this.fileIndex = fileIndex;
 	}
 
 	public String getToken(TOKEN token) {
@@ -119,7 +120,7 @@ public class FileInfo {
 	}
 
 	public void updateIndex(int index) {
-		this.index = index;
+		this.fileIndex = index;
 	}
 
 	public void setSignedURL(String url) {

--- a/server/src/main/java/com/codestates/hobby/domain/fileInfo/mapper/FileInfoMapper.java
+++ b/server/src/main/java/com/codestates/hobby/domain/fileInfo/mapper/FileInfoMapper.java
@@ -16,7 +16,7 @@ public interface FileInfoMapper {
 	@Named("Query")
 	default List<FileResponseDto> fileInfosToResponsesForQuery(List<FileInfo> infos) {
 		return infos.stream()
-			.map(info -> new FileResponseDto(info.getIndex(), info.getFileURL(), null, null))
+			.map(info -> new FileResponseDto(info.getFileIndex(), info.getFileURL(), null, null))
 			.collect(Collectors.toList());
 	}
 
@@ -30,7 +30,7 @@ public interface FileInfoMapper {
 
 	default FileResponseDto fileInfoToResponse(FileInfo fileInfo) {
 		return new FileResponseDto(
-			fileInfo.getIndex(),
+			fileInfo.getFileIndex(),
 			fileInfo.getFileURL(),
 			fileInfo.getSignedURL(),
 			fileInfo.getImageType());

--- a/server/src/main/java/com/codestates/hobby/domain/fileInfo/service/GCSFileInfoService.java
+++ b/server/src/main/java/com/codestates/hobby/domain/fileInfo/service/GCSFileInfoService.java
@@ -22,7 +22,7 @@ import com.google.cloud.storage.HttpMethod;
 import com.google.cloud.storage.Storage;
 
 @Service
-@Profile("gcs")
+@Profile("prod & gcs")
 public class GCSFileInfoService extends FileInfoService {
 	private final Storage storage;
 

--- a/server/src/main/java/com/codestates/hobby/domain/fileInfo/service/MockFileInfoService.java
+++ b/server/src/main/java/com/codestates/hobby/domain/fileInfo/service/MockFileInfoService.java
@@ -9,7 +9,7 @@ import com.codestates.hobby.domain.fileInfo.entity.FileInfo;
 import com.codestates.hobby.domain.fileInfo.repository.FileInfoRepository;
 
 @Service
-@Profile("!(gcs | aws)")
+@Profile("local")
 public class MockFileInfoService extends FileInfoService {
 	MockFileInfoService(FileInfoRepository fileInfoRepository) {
 		super(fileInfoRepository);

--- a/server/src/main/java/com/codestates/hobby/domain/fileInfo/service/S3FileInfoService.java
+++ b/server/src/main/java/com/codestates/hobby/domain/fileInfo/service/S3FileInfoService.java
@@ -11,7 +11,7 @@ import com.codestates.hobby.domain.fileInfo.entity.FileInfo;
 import com.codestates.hobby.domain.fileInfo.repository.FileInfoRepository;
 
 @Service
-@Profile("aws")
+@Profile("prod & aws")
 public class S3FileInfoService extends FileInfoService {
 	// https://docs.aws.amazon.com/ko_kr/AmazonS3/latest/userguide/ShareObjectPreSignedURL.html
 

--- a/server/src/main/java/com/codestates/hobby/domain/notifcation/entity/Notification.java
+++ b/server/src/main/java/com/codestates/hobby/domain/notifcation/entity/Notification.java
@@ -44,8 +44,7 @@ public class Notification {
 	@JoinColumn(name = "subscriber_id", nullable = false)
 	private Member requester;
 
-	@ColumnDefault(value = "CURRENT_TIMESTAMP")
-	@Column(nullable = false, updatable = false)
+	@Column(nullable = false, updatable = false, columnDefinition = "timestamp")
 	private LocalDateTime createdAt = LocalDateTime.now();
 
 	public Notification(Member target, Member requester, ResourceType resourceType, long resourceId) {

--- a/server/src/main/java/com/codestates/hobby/domain/showcase/entity/Showcase.java
+++ b/server/src/main/java/com/codestates/hobby/domain/showcase/entity/Showcase.java
@@ -53,7 +53,7 @@ public class Showcase extends BaseEntity {
 	@Transient
 	private ShowcaseComment lastComment;
 
-	@OrderBy("index asc")
+	@OrderBy("fileIndex asc")
 	@BatchSize(size = 100)
 	@OneToMany(mappedBy = "showcase", cascade = CascadeType.PERSIST, orphanRemoval = true)
 	private List<FileInfo> fileInfos = new ArrayList<>();
@@ -76,7 +76,7 @@ public class Showcase extends BaseEntity {
 	}
 
 	public void addImage(FileInfo info) {
-		FileInfo newInfo = new FileInfo(this, info.getFileURL(), info.getIndex());
+		FileInfo newInfo = new FileInfo(this, info.getFileURL(), info.getFileIndex());
 		Optional.ofNullable(info.getSignedURL())
 			.ifPresent(newInfo::setSignedURL);
 		fileInfos.add(newInfo);
@@ -98,7 +98,7 @@ public class Showcase extends BaseEntity {
 			if (idx == -1)
 				addImage(info);
 			else
-				fileInfos.get(idx).updateIndex(info.getIndex());
+				fileInfos.get(idx).updateIndex(info.getFileIndex());
 		});
 	}
 

--- a/server/src/main/java/com/codestates/hobby/domain/subscription/entity/Subscription.java
+++ b/server/src/main/java/com/codestates/hobby/domain/subscription/entity/Subscription.java
@@ -35,8 +35,7 @@ public class Subscription {
 	@JoinColumn(name = "member_id", nullable = false)
 	private Member target;
 
-	@ColumnDefault(value = "CURRENT_TIMESTAMP")
-	@Column(nullable = false, updatable = false)
+	@Column(nullable = false, updatable = false, columnDefinition = "timestamp")
 	private LocalDateTime createdAt = LocalDateTime.now();
 
 	public Subscription(Member subscriber, Member target) {

--- a/server/src/main/java/com/codestates/hobby/global/config/GCSConfig.java
+++ b/server/src/main/java/com/codestates/hobby/global/config/GCSConfig.java
@@ -10,7 +10,7 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 
-@Profile("gcs")
+@Profile("prod & gcs")
 @Configuration
 public class GCSConfig {
 	@Bean

--- a/server/src/main/java/com/codestates/hobby/global/dto/ErrorResponse.java
+++ b/server/src/main/java/com/codestates/hobby/global/dto/ErrorResponse.java
@@ -1,4 +1,4 @@
-package com.codestates.hobby.global.response;
+package com.codestates.hobby.global.dto;
 
 import lombok.Getter;
 import org.springframework.http.HttpStatus;

--- a/server/src/main/java/com/codestates/hobby/global/exception/GlobalExceptionAdvice.java
+++ b/server/src/main/java/com/codestates/hobby/global/exception/GlobalExceptionAdvice.java
@@ -1,4 +1,4 @@
-package com.codestates.hobby.global.advice;
+package com.codestates.hobby.global.exception;
 
 import javax.validation.ConstraintViolationException;
 
@@ -14,8 +14,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.MultipartException;
 
-import com.codestates.hobby.global.exception.BusinessLogicException;
-import com.codestates.hobby.global.response.ErrorResponse;
+import com.codestates.hobby.global.dto.ErrorResponse;
 
 import lombok.extern.slf4j.Slf4j;
 

--- a/server/src/main/java/com/codestates/hobby/global/support/mail/GoogleEmailService.java
+++ b/server/src/main/java/com/codestates/hobby/global/support/mail/GoogleEmailService.java
@@ -14,7 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
-@Profile("!mock")
+@Profile("prod")
 @RequiredArgsConstructor
 public class GoogleEmailService implements EmailService {
 	private final JavaMailSender mailSender;

--- a/server/src/main/java/com/codestates/hobby/global/support/mail/MockEmailService.java
+++ b/server/src/main/java/com/codestates/hobby/global/support/mail/MockEmailService.java
@@ -8,7 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
-@Profile("mock")
+@Profile("local")
 @RequiredArgsConstructor
 public class MockEmailService implements EmailService {
 	public void send(String to, String subject, String text) {

--- a/server/src/main/resources/application-local.yml
+++ b/server/src/main/resources/application-local.yml
@@ -20,6 +20,9 @@ spring:
   output:
     ansi:
       enabled: always
+  sql:
+    init:
+      mode: always
 
 logging:
   level:

--- a/server/src/main/resources/application-local.yml
+++ b/server/src/main/resources/application-local.yml
@@ -1,0 +1,28 @@
+spring:
+  datasource:
+    url: "jdbc:h2:mem:hobby;MODE=MYSQL"
+    password:
+    username: admin
+    driver-class-name: org.h2.Driver
+  h2:
+    console:
+      enabled: true
+      path: /h2
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+        generate_statistics: true
+    defer-datasource-initialization: true
+  output:
+    ansi:
+      enabled: always
+
+logging:
+  level:
+    org:
+      hibernate:
+        type: trace

--- a/server/src/main/resources/application-prod.yml
+++ b/server/src/main/resources/application-prod.yml
@@ -1,0 +1,22 @@
+spring:
+  datasource:
+    url: 'jdbc:mysql://${DB_HOST}:3306/intorest?useSSL=false&serverTimezone=UTC&characterEncoding=UTF-8'
+    username: admin
+    password: 1234
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      connection-timeout: 3000
+  jpa:
+    hibernate:
+      ddl-auto: update
+cloud:
+  storage:
+    gcs:
+      bucket-name: ${STORAGE_BUCKET}
+
+logging:
+  level:
+    org: info
+
+server:
+  port: 80

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -1,17 +1,5 @@
 spring:
-  datasource:
-    url: "jdbc:h2:mem:hobby;MODE=MYSQL"
-    password:
-    username: admin
-    driver-class-name: org.h2.Driver
-  h2:
-    console:
-      enabled: true
-      path: /h2
   jpa:
-    show-sql: true
-    hibernate:
-      ddl-auto: create
     properties:
       javax:
         cache:
@@ -20,17 +8,11 @@ spring:
           sharedCache:
             mode: ENABLE_SELECTIVE
       hibernate:
-        format_sql: true
-        generate_statistics: true
         cache:
           use_query_cache: true
           use_second_level_cache: true
           region:
             factory_class: org.hibernate.cache.jcache.JCacheRegionFactory
-    defer-datasource-initialization: true
-  output:
-    ansi:
-      enabled: always
   mail:
     host: smtp.gmail.com
     port: 587
@@ -49,12 +31,6 @@ cloud:
       domain: https://storage.cloud.google.com
       duration: 15
       bucket-name: intorest-images
-
-logging:
-  level:
-    org:
-      hibernate:
-        type: trace
 
 server:
   port: 8080

--- a/server/src/main/resources/data.sql
+++ b/server/src/main/resources/data.sql
@@ -1,4 +1,4 @@
-INSERT INTO CATEGORY(id, group_id, kor_name, eng_name)
+INSERT INTO category(id, group_id, kor_name, eng_name)
 VALUES (default, null, '스포츠', 'sports'),
        (default, null, '금융', 'finance'),
        (default, null, '게임', 'game'),
@@ -6,7 +6,7 @@ VALUES (default, null, '스포츠', 'sports'),
        (default, null, '예술/문화', 'art/culture'),
        (default, null, '창작/제작', 'creation/making');
 
-INSERT INTO CATEGORY(id, group_id, kor_name, eng_name)
+INSERT INTO category(id, group_id, kor_name, eng_name)
 VALUES (default, 1, '야구', 'baseball'),
        (default, 1, '축구', 'soccer'),
        (default, 1, '농구', 'basketball'),


### PR DESCRIPTION
## 작업내용
- `Connection Pool` 설정
  - `max, min connection`: 기본값인 10으로 유지
  - `connection timeout`: 3초
  - `max-timeout`: 기본값 30분으로 유지 (변경시 db의 `timeout`을 +2~5초로 변경해야함)

## 변경사항
- `profile`: `prod`, `local`로 나눔
- `dependency`: mysql 추가함
- `entity`
  - 시간 관련 필드의 컬럼 타입을 `timestamp`로 변경함
  - `int` 필드의 컬럼 타입 `tinyint`로 변경함 
    - `fileInfo` 엔티티의 필드명을 `fileIndex`로 변경함
  - `global` 패키지 정리
    - `advice`: `exception`으로 이동
    - `error response`: `dto`로 이동
- `propertySource` 제거함
  - `prod` 프로파일에서 실행시 필요한 환경변수
    - `STORAGE_BUCKET`: 클라우드 저장소의 버킷 이름
    - `DB_HOST`: 원격 db 주소 (포트번호는 3306 고정)
    - `EMAIL_USERNAME`: 이메일 api 사용할 수 있는 구글 계정
    - `EMAIL_PASSWORD`: 구글 계정의 앱 비밀번호