### PR TITLE
[BE/Cert] 이메일 인증 기능 구현

### DIFF
--- a/server/src/main/java/com/codestates/hobby/ServerApplication.java
+++ b/server/src/main/java/com/codestates/hobby/ServerApplication.java
@@ -3,7 +3,9 @@ package com.codestates.hobby;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @EnableJpaAuditing
 @SpringBootApplication
 public class ServerApplication {

--- a/server/src/main/java/com/codestates/hobby/domain/auth/controller/LoginController.java
+++ b/server/src/main/java/com/codestates/hobby/domain/auth/controller/LoginController.java
@@ -1,43 +1,72 @@
 package com.codestates.hobby.domain.auth.controller;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import java.util.Date;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
-import java.util.Date;
+import javax.validation.Valid;
+import javax.validation.constraints.Email;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.codestates.hobby.domain.auth.dto.CertificationPatchRequest;
+import com.codestates.hobby.domain.auth.service.CertificationService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
+@Validated
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/auth")
 public class LoginController {
+	private final CertificationService certificationService;
 
-    @GetMapping("/logout")
-    public ResponseEntity logout(HttpSession session) {
-        if(session != null) session.invalidate(); //세션 제거
+	@PostMapping("/certifications")
+	public ResponseEntity<?> attempt(@RequestBody @Email String email) {
+		certificationService.attempt(email);
+		return new ResponseEntity<>(HttpStatus.CREATED);
+	}
 
-        log.info("\n\n--로그아웃 성공--\n");
-        return new ResponseEntity("로그아웃 성공", HttpStatus.OK);
-    }
+	@PatchMapping("/certifications")
+	public ResponseEntity<?> certify(@RequestBody @Valid CertificationPatchRequest request) {
+		certificationService.certify(request);
+		return new ResponseEntity<>(HttpStatus.OK);
+	}
 
-    @GetMapping("/session-info")
-    public String sessionInfo(HttpServletRequest request){
-        HttpSession session = request.getSession(false);
-        if(session == null){
-            return "세션이 없습니다.";
-        }
-        session.getAttributeNames().asIterator()
-                .forEachRemaining(name -> log.info("session name={},value={}", name, session.getAttribute(name)));
+	@GetMapping("/logout")
+	public ResponseEntity logout(HttpSession session) {
+		if (session != null)
+			session.invalidate(); //세션 제거
 
-        log.info("sessionId={}",session.getId());
-        log.info("getMaxInactiveInterval={}",session.getMaxInactiveInterval());
-        log.info("creationTime={}", new Date(session.getCreationTime()));
-        log.info("lastAccessedTime={}", new Date(session.getLastAccessedTime()));
-        log.info("isNew={}", session.isNew());
+		log.info("\n\n--로그아웃 성공--\n");
+		return new ResponseEntity("로그아웃 성공", HttpStatus.OK);
+	}
 
-        return "세션 출력";
-    }
+	@GetMapping("/session-info")
+	public String sessionInfo(HttpServletRequest request) {
+		HttpSession session = request.getSession(false);
+		if (session == null) {
+			return "세션이 없습니다.";
+		}
+		session.getAttributeNames().asIterator()
+			.forEachRemaining(name -> log.info("session name={},value={}", name, session.getAttribute(name)));
+
+		log.info("sessionId={}", session.getId());
+		log.info("getMaxInactiveInterval={}", session.getMaxInactiveInterval());
+		log.info("creationTime={}", new Date(session.getCreationTime()));
+		log.info("lastAccessedTime={}", new Date(session.getLastAccessedTime()));
+		log.info("isNew={}", session.isNew());
+
+		return "세션 출력";
+	}
 }

--- a/server/src/main/java/com/codestates/hobby/domain/auth/dto/CertificationCreatedEvent.java
+++ b/server/src/main/java/com/codestates/hobby/domain/auth/dto/CertificationCreatedEvent.java
@@ -1,4 +1,4 @@
-package com.codestates.hobby.domain.auth.event;
+package com.codestates.hobby.domain.auth.dto;
 
 import lombok.Getter;
 

--- a/server/src/main/java/com/codestates/hobby/domain/auth/dto/CertificationPatchRequest.java
+++ b/server/src/main/java/com/codestates/hobby/domain/auth/dto/CertificationPatchRequest.java
@@ -1,0 +1,18 @@
+package com.codestates.hobby.domain.auth.dto;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+
+import org.hibernate.validator.constraints.Range;
+
+import lombok.Getter;
+
+@Getter
+public class CertificationPatchRequest {
+	@Email
+	@NotBlank(message = "Email must not be empty.")
+	private String email;
+
+	@Range(min = 0, max = 100_000_000, message = "Code must be between 0 and 1000000.")
+	private int code;
+}

--- a/server/src/main/java/com/codestates/hobby/domain/auth/repository/CertificationRepository.java
+++ b/server/src/main/java/com/codestates/hobby/domain/auth/repository/CertificationRepository.java
@@ -1,0 +1,11 @@
+package com.codestates.hobby.domain.auth.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.codestates.hobby.domain.auth.entity.Certification;
+
+public interface CertificationRepository extends JpaRepository<Certification, Long> {
+	Optional<Certification> findByEmail(String email);
+}

--- a/server/src/main/java/com/codestates/hobby/domain/auth/service/CertificationEventHandler.java
+++ b/server/src/main/java/com/codestates/hobby/domain/auth/service/CertificationEventHandler.java
@@ -1,11 +1,12 @@
 package com.codestates.hobby.domain.auth.service;
 
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
 
-import com.codestates.hobby.domain.auth.event.CertificationCreatedEvent;
+import com.codestates.hobby.domain.auth.dto.CertificationCreatedEvent;
 import com.codestates.hobby.global.support.mail.EmailService;
 
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,7 @@ public class CertificationEventHandler {
 	private final TemplateEngine templateEngine;
 	private final EmailService emailService;
 
+	@Async
 	@TransactionalEventListener
 	public void handleCertificationCreatedEvent(CertificationCreatedEvent event) {
 		Context context = new Context();

--- a/server/src/main/java/com/codestates/hobby/domain/auth/service/CertificationService.java
+++ b/server/src/main/java/com/codestates/hobby/domain/auth/service/CertificationService.java
@@ -1,0 +1,66 @@
+package com.codestates.hobby.domain.auth.service;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.codestates.hobby.domain.auth.dto.CertificationCreatedEvent;
+import com.codestates.hobby.domain.auth.dto.CertificationPatchRequest;
+import com.codestates.hobby.domain.auth.entity.Certification;
+import com.codestates.hobby.domain.auth.repository.CertificationRepository;
+import com.codestates.hobby.domain.member.repository.MemberRepository;
+import com.codestates.hobby.global.exception.BusinessLogicException;
+import com.codestates.hobby.global.exception.ExceptionCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CertificationService {
+	private final CertificationRepository certificationRepository;
+	private final MemberRepository memberRepository;
+
+	private final ApplicationEventPublisher eventPublisher;
+
+	public void attempt(String email) {
+		verifyNotExistEmail(email);
+
+		Certification cert = certificationRepository.findByEmail(email)
+			.orElseGet(() -> certificationRepository.save(new Certification(email)));
+
+		cert.initCode();
+
+		eventPublisher.publishEvent(new CertificationCreatedEvent(email, cert.getCode()));
+	}
+
+	public void certify(CertificationPatchRequest request) {
+		Certification cert = findCertification(request.getEmail(), ExceptionCode.NOT_FOUND_EMAIL);
+
+		if (cert.isCertified()) return;
+
+		cert.validate();
+
+		if (!cert.matches(request.getCode()))
+			throw new BusinessLogicException(ExceptionCode.CERTIFICATION_NOT_MATCH);
+	}
+
+	public void verifyEmail(String email) {
+		Certification cert = findCertification(email, ExceptionCode.NOT_CERTIFICATION);
+
+		if (!cert.isCertified())
+			throw new BusinessLogicException(ExceptionCode.NOT_CERTIFIED);
+
+		certificationRepository.delete(cert);
+	}
+
+	private Certification findCertification(String email, ExceptionCode code) {
+		return certificationRepository.findByEmail(email)
+			.orElseThrow(() -> new BusinessLogicException(code));
+	}
+
+	private void verifyNotExistEmail(String email) {
+		if (memberRepository.existsByEmail(email))
+			throw new BusinessLogicException(ExceptionCode.EXISTS_EMAIL);
+	}
+}

--- a/server/src/main/java/com/codestates/hobby/domain/member/repository/MemberRepository.java
+++ b/server/src/main/java/com/codestates/hobby/domain/member/repository/MemberRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
     Optional<Member> findByNickname(String nickname);
+    boolean existsByEmail(String email);
 }

--- a/server/src/main/java/com/codestates/hobby/domain/member/service/MemberService.java
+++ b/server/src/main/java/com/codestates/hobby/domain/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.codestates.hobby.domain.member.service;
 
+import com.codestates.hobby.domain.auth.service.CertificationService;
 import com.codestates.hobby.domain.auth.utils.CustomAuthorityUtils;
 import com.codestates.hobby.domain.member.dto.MemberDto;
 import com.codestates.hobby.domain.member.repository.MemberRepository;
@@ -23,11 +24,13 @@ import java.util.Optional;
 public class MemberService {
     private final MemberRepository repository;
     private final PasswordEncoder passwordEncoder;
-
+    private final CertificationService certificationService;
     private final CustomAuthorityUtils authorityUtils;
 
     @Transactional
     public Member create(MemberDto.Post post) {
+        certificationService.verifyEmail(post.getEmail());
+
         verifyExistEmail(post.getEmail());
         verifyExistNickname(post.getNickname());
         String encryptedPassword = passwordEncoder.encode(post.getPassword());
@@ -66,13 +69,13 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
-    private void verifyExistEmail(String email) {
+    protected void verifyExistEmail(String email) {
         Optional<Member> member = repository.findByEmail(email);
         if(member.isPresent()) throw new BusinessLogicException(ExceptionCode.EXISTS_EMAIL);
     }
 
     @Transactional(readOnly = true)
-    private void verifyExistNickname(String nickname) {
+    protected void verifyExistNickname(String nickname) {
         Optional<Member> member = repository.findByNickname(nickname);
         if(member.isPresent()) throw new BusinessLogicException(ExceptionCode.EXISTS_NICKNAME);
     }

--- a/server/src/main/java/com/codestates/hobby/global/dto/ErrorResponse.java
+++ b/server/src/main/java/com/codestates/hobby/global/dto/ErrorResponse.java
@@ -38,6 +38,10 @@ public class ErrorResponse {
         return new ErrorResponse(httpStatus.value(), httpStatus.getReasonPhrase());
     }
 
+    public static ErrorResponse of(HttpStatus httpStatus, String message) {
+        return new ErrorResponse(httpStatus.value(), message);
+    }
+
     @Getter
     public static class FieldError {
         private String field;

--- a/server/src/main/java/com/codestates/hobby/global/exception/ExceptionCode.java
+++ b/server/src/main/java/com/codestates/hobby/global/exception/ExceptionCode.java
@@ -3,8 +3,13 @@ package com.codestates.hobby.global.exception;
 import lombok.Getter;
 
 public enum ExceptionCode {
+    // BAD REQUEST
+    CERTIFICATION_NOT_MATCH(400, "Invalid code."),
+    CODE_EXPIRATION(400, "This code has expired."),
+
     // UNAUTHORIZED
     UNAUTHORIZED(401,"Unauthorized"),
+    NOT_CERTIFIED(401,"Certification required."),
 
     // FORBIDDEN
     NO_PERMISSION_TO_EDIT(403, ""),
@@ -14,6 +19,8 @@ public enum ExceptionCode {
     NOT_MATCH_MEMBER(500, "Doesn't Belong This Member"),
 
     // NOT FOUND
+    NOT_CERTIFICATION(404, "It is not certified"),
+    NOT_FOUND_EMAIL(404, "Email not found"),
     NOT_FOUND_POST(404, "Post Not Found"),
     NOT_FOUND_MEMBER(404, "Member Not Found"),
     NOT_FOUND_SERIES(404,"Series Not Found"),

--- a/server/src/main/java/com/codestates/hobby/global/exception/GlobalExceptionAdvice.java
+++ b/server/src/main/java/com/codestates/hobby/global/exception/GlobalExceptionAdvice.java
@@ -53,7 +53,8 @@ public class GlobalExceptionAdvice {
 	@ExceptionHandler
 	public ResponseEntity<?> handleBusinessLogicException(BusinessLogicException e) {
 		log.debug("Business logic exception ocurred: {}", e.getMessage());
-		return new ResponseEntity<>(HttpStatus.valueOf(e.getExceptionCode().getStatus()));
+		HttpStatus status = HttpStatus.valueOf(e.getExceptionCode().getStatus());
+		return new ResponseEntity<>(ErrorResponse.of(status, e.getExceptionCode().getMessage()), status);
 	}
 
 	@ExceptionHandler

--- a/server/src/main/java/com/codestates/hobby/global/support/mail/GoogleEmailService.java
+++ b/server/src/main/java/com/codestates/hobby/global/support/mail/GoogleEmailService.java
@@ -6,7 +6,6 @@ import javax.mail.internet.MimeMessage;
 import org.springframework.context.annotation.Profile;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
@@ -19,7 +18,6 @@ import lombok.extern.slf4j.Slf4j;
 public class GoogleEmailService implements EmailService {
 	private final JavaMailSender mailSender;
 
-	@Async
 	public void send(String to, String subject, String text) {
 		MimeMessage mimeMessage = mailSender.createMimeMessage();
 

--- a/server/src/main/resources/application-prod.yml
+++ b/server/src/main/resources/application-prod.yml
@@ -16,8 +16,8 @@ cloud:
 
 logging:
   level:
-    org: warn
-    com: warn
+    org: info
+    com: info
 
 server:
   port: 80


### PR DESCRIPTION
## 개요
- 이메일 인증 기능 구현

## 작업내용
- 이메일 인증 엔티티, DTO 구현
- 인증 서비스 구현

## 변경사항
- 회원가입시 사용된 이메일의 인증여부 확인하는 로직 추가
- 비동기 처리를 EmailService에서 EventHandler가 하도록 수정
- `ControllerAdvice`의 리턴 값에 메세지 포함하도록 수정
- `LoginController` 에 `RequestMapping("/auth")` 어노테이션 추가함 