### PR TITLE
[BE/Config] 예외 및 Security 설정 리펙토링

### DIFF
--- a/server/src/main/java/com/codestates/hobby/domain/showcase/dto/ShowcaseCommentDto.java
+++ b/server/src/main/java/com/codestates/hobby/domain/showcase/dto/ShowcaseCommentDto.java
@@ -5,23 +5,20 @@ import java.time.LocalDateTime;
 import javax.validation.constraints.NotBlank;
 
 import com.codestates.hobby.domain.member.dto.MemberDto;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 public class ShowcaseCommentDto {
 	@Getter
-	@Setter
-	@NoArgsConstructor
 	@JsonIgnoreProperties({"showcaseId", "memberId"})
-	public static class Post {
-		private Long showcaseId;
-		private Long memberId;
-
+	public static abstract class Request {
 		@NotBlank(message = "Content must not be empty.")
 		private String content;
+		private Long showcaseId;
+		private Long memberId;
 
 		public void setProperties(Long showcaseId, Long memberId) {
 			this.showcaseId = showcaseId;
@@ -29,28 +26,22 @@ public class ShowcaseCommentDto {
 		}
 	}
 
-	@Getter
-	@Setter
-	@NoArgsConstructor
-	@JsonIgnoreProperties({"memberId", "showcaseId", "commentId"})
-	public static class Patch {
-		private Long showcaseId;
-		private Long commentId;
-		private Long memberId;
+	public static class Post extends Request {
+	}
 
-		@NotBlank(message = "Content must not be empty.")
-		private String content;
+	@Getter
+	public static class Patch  extends Request {
+		@JsonIgnore
+		private Long commentId;
 
 		public void setProperties(Long memberId, Long showcaseId, Long commentId) {
-			this.showcaseId = showcaseId;
+			this.setProperties(showcaseId, memberId);
 			this.commentId = commentId;
-			this.memberId = memberId;
 		}
 	}
 
 	@Getter
 	@Setter
-	@NoArgsConstructor
 	public static class Response {
 		private long id;
 		private String content;

--- a/server/src/main/java/com/codestates/hobby/global/config/SecurityConfig.java
+++ b/server/src/main/java/com/codestates/hobby/global/config/SecurityConfig.java
@@ -68,7 +68,8 @@ public class SecurityConfig {
 	CorsConfigurationSource corsConfigurationSource() {
 		CorsConfiguration configuration = new CorsConfiguration();
 		configuration.setAllowedOrigins(
-			List.of("http://localhost:3000", "http://127.0.0.1:3000", "http://intorest.s3-website.ap-northeast-2.amazonaws.com"));
+			List.of("http://localhost:3000", "http://127.0.0.1:3000",
+				"http://intorest.s3-website.ap-northeast-2.amazonaws.com", "http://intorestbackup.s3-website.ap-northeast-2.amazonaws.com"));
 		configuration.setAllowedMethods(List.of("GET", "POST", "PATCH", "DELETE", "OPTIONS", "HEAD"));
 		configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "Cache-Control"));
 		configuration.setExposedHeaders(List.of("Authorization"));

--- a/server/src/main/java/com/codestates/hobby/global/config/SecurityConfig.java
+++ b/server/src/main/java/com/codestates/hobby/global/config/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig {
 			.formLogin().disable()
 			.httpBasic().disable();
 		http.authorizeHttpRequests(authorize -> authorize
-			.mvcMatchers(HttpMethod.GET, "/categories").permitAll()
+			.mvcMatchers(HttpMethod.GET, "/members", "/series", "/showcases", "/posts", "/categories").permitAll()
 			.mvcMatchers(HttpMethod.GET, "/members/**", "/series/**", "/showcases/**", "/posts/**", "/categories/**").permitAll()
 			.anyRequest().permitAll());
 		http.sessionManagement()

--- a/server/src/main/java/com/codestates/hobby/global/config/SecurityConfig.java
+++ b/server/src/main/java/com/codestates/hobby/global/config/SecurityConfig.java
@@ -48,11 +48,8 @@ public class SecurityConfig {
 			.formLogin().disable()
 			.httpBasic().disable();
 		http.authorizeHttpRequests(authorize -> authorize
-			// TODO: 추가하기
-			.antMatchers(HttpMethod.POST, "/series", "/showcases", "/posts").authenticated()
-			.antMatchers(HttpMethod.PATCH, "/members/**", "/series/**", "/showcases/**", "/posts/**").authenticated()
-			.antMatchers(HttpMethod.DELETE, "/members/**", "/series/**", "/showcases/**", "/posts/**").authenticated()
-			//.antMatchers(HttpMethod.GET, "/members").authenticated()
+			.mvcMatchers(HttpMethod.GET, "/categories").permitAll()
+			.mvcMatchers(HttpMethod.GET, "/members/**", "/series/**", "/showcases/**", "/posts/**", "/categories/**").permitAll()
 			.anyRequest().permitAll());
 		http.sessionManagement()
 			.sessionFixation().changeSessionId()

--- a/server/src/main/java/com/codestates/hobby/global/config/SecurityConfig.java
+++ b/server/src/main/java/com/codestates/hobby/global/config/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig {
 			.formLogin().disable()
 			.httpBasic().disable();
 		http.authorizeHttpRequests(authorize -> authorize
-			.mvcMatchers(HttpMethod.GET, "/members", "/series", "/showcases", "/posts", "/categories").permitAll()
+			.mvcMatchers(HttpMethod.GET, "/series", "/showcases", "/posts", "/categories").permitAll()
 			.mvcMatchers(HttpMethod.GET, "/members/**", "/series/**", "/showcases/**", "/posts/**", "/categories/**").permitAll()
 			.anyRequest().permitAll());
 		http.sessionManagement()

--- a/server/src/main/java/com/codestates/hobby/global/exception/GlobalExceptionAdvice.java
+++ b/server/src/main/java/com/codestates/hobby/global/exception/GlobalExceptionAdvice.java
@@ -1,3 +1,4 @@
+
 package com.codestates.hobby.global.exception;
 
 import javax.validation.ConstraintViolationException;
@@ -6,6 +7,7 @@ import org.springframework.beans.TypeMismatchException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
@@ -40,14 +42,21 @@ public class GlobalExceptionAdvice {
 	})
 	public ErrorResponse handleBadRequestException(Exception e) {
 		log.debug("Bad request exception occurred: {}", e.getMessage(), e);
-		return ErrorResponse.of(HttpStatus.BAD_REQUEST);
+		return ErrorResponse.of(HttpStatus.BAD_REQUEST, e.getMessage());
+	}
+
+	@ExceptionHandler
+	@ResponseStatus(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
+	public ErrorResponse handleMediaTypeNotSupportedException(HttpMediaTypeNotSupportedException e) {
+		log.debug("MediaTypeNotSupportedException: {}", e.getMessage(), e);
+		return ErrorResponse.of(HttpStatus.UNSUPPORTED_MEDIA_TYPE, e.getMessage());
 	}
 
 	@ExceptionHandler
 	@ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
 	public ErrorResponse handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
 		log.debug("Request method not supported exception: {}", e.getMessage(), e);
-		return ErrorResponse.of(HttpStatus.METHOD_NOT_ALLOWED);
+		return ErrorResponse.of(HttpStatus.METHOD_NOT_ALLOWED, e.getMessage());
 	}
 
 	@ExceptionHandler
@@ -61,6 +70,6 @@ public class GlobalExceptionAdvice {
 	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
 	public ErrorResponse handleException(Exception e) {
 		log.error("# handle Exception", e);
-		return ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
+		return ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
 	}
 }

--- a/server/src/test/java/com/codestates/hobby/domain/category/controller/CategoryIntegrationTest.java
+++ b/server/src/test/java/com/codestates/hobby/domain/category/controller/CategoryIntegrationTest.java
@@ -7,10 +7,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@ActiveProfiles("local")
 public class CategoryIntegrationTest {
 	@Autowired
 	MockMvc mvc;


### PR DESCRIPTION
## 변경사항
- `Advice`
  - 반환시 예외 메세지 보내도록 변경
  - `HttpMediaTypeNotSupportedException` 추가
- `Security`: authorize http requests 변경
- `Showcase Comment Dto`: 추상화