### PR TITLE
[Be/member] 가입 로직 변경

### DIFF
--- a/server/src/main/java/com/codestates/hobby/domain/member/dto/MemberDto.java
+++ b/server/src/main/java/com/codestates/hobby/domain/member/dto/MemberDto.java
@@ -29,11 +29,6 @@ public class MemberDto {
         @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[$@$!%*#?&])[A-Za-z\\d$@$!%*#?&]{8,}$",
                 message = "최소 하나의 문자, 숫자, 특문를 포함해야하며 8자리 이상")
         private String password;
-
-        @Size(max = 255, message = "255자 이하로 제한됩니다.")
-        private String introduction;
-
-        private String profileUrl;
     }
 
     @Getter

--- a/server/src/main/java/com/codestates/hobby/domain/member/entity/Member.java
+++ b/server/src/main/java/com/codestates/hobby/domain/member/entity/Member.java
@@ -48,6 +48,9 @@ public class Member extends BaseEntity implements Serializable {
 
 	private boolean isOauth2;
 
+	@Column(nullable = false)
+	private String defaultProfile;
+
 	@Enumerated(value = EnumType.STRING)
 	@Column
 	private MemberStatus memberStatus = MemberStatus.MEMBER_ACTIVE;
@@ -58,13 +61,13 @@ public class Member extends BaseEntity implements Serializable {
 	@OneToOne(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST, orphanRemoval = true)
 	private FileInfo image;
 
-	public Member(String email, String nickname, String password, String introduction, boolean isOauth2, List<String> roles) {
+	public Member(String email, String nickname, String password, boolean isOauth2, List<String> roles, String url) {
 		this.email = email;
 		this.nickname = nickname;
 		this.password = password;
-		this.introduction = introduction;
 		this.isOauth2 = isOauth2;
 		this.roles = roles;
+		this.defaultProfile = url;
 	}
 
 	public void edit(String nickname, String introduction, String profileUrl) {
@@ -72,8 +75,10 @@ public class Member extends BaseEntity implements Serializable {
 			this.nickname = nickname;
 		if (Optional.ofNullable(introduction).isPresent())
 			this.introduction = introduction;
-		if (Optional.ofNullable(profileUrl).isPresent())
+		if (Optional.ofNullable(profileUrl).isPresent()) {
 			setImage(profileUrl);
+			this.defaultProfile = profileUrl;
+		}
 	}
 
 	public void setStatus(MemberStatus memberStatus) {

--- a/server/src/main/java/com/codestates/hobby/domain/member/mapper/MemberMapper.java
+++ b/server/src/main/java/com/codestates/hobby/domain/member/mapper/MemberMapper.java
@@ -7,9 +7,9 @@ import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface MemberMapper {
-    @Mapping(target = "profileUrl", expression = "java(member.getImage().getFileURL())")
+    @Mapping(target = "profileUrl", expression = "java(member.getDefaultProfile())")
     MemberDto.Response MemberToResponseDto(Member member);
 
-    @Mapping(target = "profileUrl", expression = "java(member.getImage().getFileURL())")
+    @Mapping(target = "profileUrl", expression = "java(member.getDefaultProfile())")
     MemberDto.SimpleResponse MemberToSimpleResponseDto(Member member);
 }

--- a/server/src/main/java/com/codestates/hobby/domain/member/service/MemberService.java
+++ b/server/src/main/java/com/codestates/hobby/domain/member/service/MemberService.java
@@ -35,8 +35,9 @@ public class MemberService {
         verifyExistNickname(post.getNickname());
         String encryptedPassword = passwordEncoder.encode(post.getPassword());
         List<String> roles = authorityUtils.createRoles(post.getEmail());
+        String url = "https://cdn-icons-png.flaticon.com/512/1946/1946429.png";
 
-        return repository.save(new Member(post.getEmail(), post.getNickname(), encryptedPassword, post.getIntroduction(), false, roles));
+        return repository.save(new Member(post.getEmail(), post.getNickname(), encryptedPassword,false, roles, url));
     }
 
     @Transactional


### PR DESCRIPTION
## 변경사항
- Member Entity에 defaultProfile 컬럼 추가
- 가입 시 기본 프로필 사진을 지정해줌
- 사진을 변경하면 추가한 사진의 URL이 fileInfo에 저장되며 defaultProfile이 해당 URL로 변경됨
- response시 fileinfo의 fileUrl이 아닌 defaultProfile를 응답하도록 변경