### PR TITLE
[Be/member] Member 리팩토링

### DIFF
--- a/server/src/main/java/com/codestates/hobby/domain/member/entity/Member.java
+++ b/server/src/main/java/com/codestates/hobby/domain/member/entity/Member.java
@@ -48,9 +48,6 @@ public class Member extends BaseEntity implements Serializable {
 
 	private boolean isOauth2;
 
-	@Column(nullable = false)
-	private String defaultProfile;
-
 	@Enumerated(value = EnumType.STRING)
 	@Column
 	private MemberStatus memberStatus = MemberStatus.MEMBER_ACTIVE;
@@ -61,13 +58,12 @@ public class Member extends BaseEntity implements Serializable {
 	@OneToOne(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST, orphanRemoval = true)
 	private FileInfo image;
 
-	public Member(String email, String nickname, String password, boolean isOauth2, List<String> roles, String url) {
+	public Member(String email, String nickname, String password, boolean isOauth2, List<String> roles) {
 		this.email = email;
 		this.nickname = nickname;
 		this.password = password;
 		this.isOauth2 = isOauth2;
 		this.roles = roles;
-		this.defaultProfile = url;
 	}
 
 	public void edit(String nickname, String introduction, String profileUrl) {
@@ -77,7 +73,6 @@ public class Member extends BaseEntity implements Serializable {
 			this.introduction = introduction;
 		if (Optional.ofNullable(profileUrl).isPresent()) {
 			setImage(profileUrl);
-			this.defaultProfile = profileUrl;
 		}
 	}
 

--- a/server/src/main/java/com/codestates/hobby/domain/member/mapper/MemberMapper.java
+++ b/server/src/main/java/com/codestates/hobby/domain/member/mapper/MemberMapper.java
@@ -7,9 +7,9 @@ import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface MemberMapper {
-    @Mapping(target = "profileUrl", expression = "java(member.getDefaultProfile())")
+    @Mapping(target = "profileUrl", source = "image.fileURL", defaultValue = "https://cdn-icons-png.flaticon.com/512/1946/1946429.png")
     MemberDto.Response MemberToResponseDto(Member member);
 
-    @Mapping(target = "profileUrl", expression = "java(member.getDefaultProfile())")
+    @Mapping(target = "profileUrl", source = "image.fileURL", defaultValue = "https://cdn-icons-png.flaticon.com/512/1946/1946429.png")
     MemberDto.SimpleResponse MemberToSimpleResponseDto(Member member);
 }

--- a/server/src/main/java/com/codestates/hobby/domain/member/service/MemberService.java
+++ b/server/src/main/java/com/codestates/hobby/domain/member/service/MemberService.java
@@ -35,9 +35,8 @@ public class MemberService {
         verifyExistNickname(post.getNickname());
         String encryptedPassword = passwordEncoder.encode(post.getPassword());
         List<String> roles = authorityUtils.createRoles(post.getEmail());
-        String url = "https://cdn-icons-png.flaticon.com/512/1946/1946429.png";
 
-        return repository.save(new Member(post.getEmail(), post.getNickname(), encryptedPassword,false, roles, url));
+        return repository.save(new Member(post.getEmail(), post.getNickname(), encryptedPassword,false, roles));
     }
 
     @Transactional

--- a/server/src/main/java/com/codestates/hobby/global/config/SecurityConfig.java
+++ b/server/src/main/java/com/codestates/hobby/global/config/SecurityConfig.java
@@ -50,8 +50,9 @@ public class SecurityConfig {
 			.formLogin().disable()
 			.httpBasic().disable();
 		http.authorizeHttpRequests(authorize -> authorize
+			.mvcMatchers(HttpMethod.POST, "/members").permitAll()
 			.mvcMatchers(HttpMethod.GET, "/series", "/showcases", "/posts", "/categories").permitAll()
-			.mvcMatchers(HttpMethod.GET, "/members/**", "/series/**", "/showcases/**", "/posts/**", "/categories/**").permitAll()
+			.mvcMatchers(HttpMethod.GET, "/series/**", "/showcases/**", "/posts/**", "/categories/**").permitAll()
 			.anyRequest().authenticated());
 		http.sessionManagement()
 			.sessionFixation().changeSessionId()


### PR DESCRIPTION
## 변경사항
- Member Entity에 defaultProfile 컬럼 제거
- response 매핑시 fileinfo에 파일이 등록된 경우 해당 파일의 url을 반환하며 없는 경우 기본 이미지 url을 반환
- member post는 권한이 필요없으므로 추가, member get은 권한이 필요하므로 제거